### PR TITLE
pylint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.10"
       - uses: pre-commit/action@v3.0.0
         with:
           extra_args: --hook-stage manual --all-files --show-diff-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ README.tmp.html
 # Venvs
 .env
 .venv
+# direnv
+.direnv
+.envrc
 
 # pdm and pep582
 .pdm.toml

--- a/constraints.txt
+++ b/constraints.txt
@@ -31,6 +31,7 @@ docutils==0.19
 emcee==3.1.3
 entrypoints==0.4
 et-xmlfile==1.1.0
+exceptiongroup==1.0.4
 executing==1.2.0
 fastjsonschema==2.16.2
 fonttools==4.38.0
@@ -136,6 +137,7 @@ sympy==1.11.1
 termcolor==2.1.1
 terminado==0.17.1
 tinycss2==1.2.1
+tomli==2.0.1
 tomlkit==0.11.6
 tornado==6.2
 tqdm==4.64.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,6 +267,6 @@ messages_control.disable = [
   # "comparison-of-constants",
   # "consider-using-with",
   # "use-maxsplit-arg",
-  # "unnecessary-dunder-call",
+  "unnecessary-dunder-call",
 ]
 # messages_control.enable = ["raise-missing-from"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,8 @@ known_first_party="clophfit"
 minversion = "6.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 # xfail_strict = true
-# filterwarnings = ["error", "ignore::DeprecationWarning"]
+# filterwarnings = ["ignore::DeprecationWarning", "ignore:OVER"]
+filterwarnings = ["ignore::DeprecationWarning"]
 log_cli_level = "INFO"
 testpaths = [
   "tests",

--- a/src/clophfit/__main__.py
+++ b/src/clophfit/__main__.py
@@ -76,12 +76,11 @@ def fit_routine(
 
 @click.group()
 @click.version_option()
-def clop() -> None:
+def clop() -> None:  # pragma: no cover
     """Group command."""
 
 
 @clop.command()
-@click.option("--some", flag_value="bello", is_flag=False, show_default="LLL")
 @click.argument("kd1", type=float)
 @click.argument("pka", type=float)
 @click.argument("ph", type=float)
@@ -89,11 +88,8 @@ def eq1(  # type: ignore
     kd1,
     pka,
     ph,
-    some,
 ):
     """pH-deps for Kd."""
-    if some:
-        print(some)
     print(binding.kd(kd1=kd1, pka=pka, ph=ph))
 
 

--- a/src/clophfit/__main__.py
+++ b/src/clophfit/__main__.py
@@ -78,7 +78,6 @@ def fit_routine(
 @click.version_option()
 def clop() -> None:
     """Group command."""
-    pass
 
 
 @clop.command()
@@ -215,7 +214,7 @@ def tecan(  # type: ignore
             if kind.lower() == "cl":  # XXX cl conc must be elsewhere
                 titan.conc = list(prtecan.calculate_conc(titan.additions, 1000.0))  # type: ignore
     titan.export_data(out)
-    with open(out / "metadata-labels.txt", "w") as fp:
+    with open(out / "metadata-labels.txt", "w", encoding="utf-8") as fp:
         for lbg in titan.labelblocksgroups:
             pprint.pprint(lbg.metadata, stream=fp)
     if scheme:

--- a/src/clophfit/__main__.py
+++ b/src/clophfit/__main__.py
@@ -40,11 +40,11 @@ def fit_routine(
         if verbose:
             try:
                 meta = titan.labelblocksgroups[i].metadata
-                print("{:s}".format("-" * 79))
+                print("-" * 79)
                 print(f"\nlabel{i:d}")
                 pprint.pprint(meta)
             except IndexError:
-                print("{:s}".format("-" * 79))
+                print("-" * 79)
                 print("\nGlobal on both labels")
             titan.print_fitting(i)
         # Csv tables

--- a/src/clophfit/prtecan.py
+++ b/src/clophfit/prtecan.py
@@ -1404,7 +1404,9 @@ class TitrationAnalysis(Titration):
                 y - self.fz(df.K.loc[key], [df.SA.loc[key], df.SB.loc[key]], x)
             )
             # Print out.
-            line = ["%1.2f" % v for v in list(df[out].loc[key])]
+            line = [
+                f"{v:.3g}" if v < 1e4 else f"{v:.0f}" for v in list(df[out].loc[key])
+            ]
             for _i in range(4):
                 line.append("")
             lines.append(line)
@@ -1422,7 +1424,9 @@ class TitrationAnalysis(Titration):
         ax_data.legend()
         # global
         df = self.fittings[-1]
-        lines.append(["%1.2f" % v for v in list(df[out2].loc[key])])
+        lines.append(
+            [f"{v:.3g}" if v < 1e4 else f"{v:.0f}" for v in list(df[out2].loc[key])]
+        )
         ax_data.plot(
             xfit,
             self.fz(df.K.loc[key], [df.SA.loc[key], df.SB.loc[key]], xfit),

--- a/src/clophfit/prtecan.py
+++ b/src/clophfit/prtecan.py
@@ -193,7 +193,7 @@ def extract_metadata(
     return md
 
 
-def _merge_md(mds: list[dict[str, Metadata]]) -> dict[str, Metadata]:
+def merge_md(mds: list[dict[str, Metadata]]) -> dict[str, Metadata]:
     """Merge a list of metadata dict if the key value is the same in the list."""
     mmd = {k: v for k, v in mds[0].items() if all(v == md[k] for md in mds[1:])}
     # To account for the case 93"Optimal" and 93"Manual" in lb metadata
@@ -730,7 +730,7 @@ class LabelblocksGroup:
                     self._data_norm[key].append(lb.data_norm[key])
         else:
             raise ValueError("Creation of labelblock group failed.")
-        self.metadata = _merge_md([lb.metadata for lb in self.labelblocks])
+        self.metadata = merge_md([lb.metadata for lb in self.labelblocks])
 
     @property
     def data(self) -> dict[str, list[float]] | None:
@@ -852,7 +852,7 @@ class TecanfilesGroup:
             if len(self.labelblocksgroups) == 0:  # == []
                 raise ValueError(f"No common labelblock in filenames: {files}.")
             warnings.warn(f"Different LabelblocksGroup among filenames: {files}.")
-        self.metadata = _merge_md([tf.metadata for tf in self.tecanfiles])
+        self.metadata = merge_md([tf.metadata for tf in self.tecanfiles])
 
 
 @dataclass

--- a/src/clophfit/prtecan.py
+++ b/src/clophfit/prtecan.py
@@ -827,7 +827,7 @@ class TecanfilesGroup:
         """Create metadata and labelblocksgroups."""
         n_labelblocks = [len(tf.labelblocks) for tf in self.tecanfiles]
         tf0 = self.tecanfiles[0]
-        if all([tf0.labelblocks == tf.labelblocks for tf in self.tecanfiles[1:]]):
+        if all(tf0.labelblocks == tf.labelblocks for tf in self.tecanfiles[1:]):
             # Same number and order of labelblocks
             for i, _lb in enumerate(tf0.labelblocks):
                 self.labelblocksgroups.append(
@@ -837,7 +837,7 @@ class TecanfilesGroup:
                 )
         else:
             # Create as many as possible groups of labelblocks
-            rngs = tuple([range(n) for n in n_labelblocks])
+            rngs = tuple(range(n) for n in n_labelblocks)
             for idx in itertools.product(*rngs):
                 try:
                     gr = LabelblocksGroup(
@@ -851,8 +851,7 @@ class TecanfilesGroup:
             files = [tf.path for tf in self.tecanfiles]
             if len(self.labelblocksgroups) == 0:  # == []
                 raise ValueError(f"No common labelblock in filenames: {files}.")
-            else:
-                warnings.warn(f"Different LabelblocksGroup among filenames: {files}.")
+            warnings.warn(f"Different LabelblocksGroup among filenames: {files}.")
         self.metadata = _merge_md([tf.metadata for tf in self.tecanfiles])
 
 
@@ -890,7 +889,8 @@ class Titration(TecanfilesGroup):
         -------
         Titration
         """
-        tecanfiles, conc = TitrationAnalysis._listfile(Path(list_file))
+        # tecanfiles, conc = TitrationAnalysis._listfile(Path(list_file))
+        tecanfiles, conc = Titration._listfile(Path(list_file))
         return cls(tecanfiles, conc)
 
     @staticmethod

--- a/src/clophfit/prtecan.py
+++ b/src/clophfit/prtecan.py
@@ -78,15 +78,15 @@ def lookup_listoflines(
         Row/line index for all occurrences of pattern. Empty list for no occurrences.
 
     """
-    return [
-        tuple_i_line[0]
-        for tuple_i_line in list(
-            filter(
-                lambda x: pattern in x[1][0] if isinstance(x[1][0], str) else None,
-                enumerate(csvl),
-            )
-        )
-    ]
+    indexes = []
+    for i, line in enumerate(csvl):
+        try:
+            if isinstance(line[col], str):
+                if pattern in str(line[col]):
+                    indexes.append(i)
+        except IndexError:
+            continue
+    return indexes
 
 
 def strip_lines(lines: list[list[str | int | float]]) -> list[list[str | int | float]]:
@@ -1534,7 +1534,7 @@ class TitrationAnalysis(Titration):
             df = df[~np.isnan(df[y])]
             for idx, xv, yv, l in zip(df.index, df[x], df[y], df["ctrl"]):
                 # x or y do not exhist.# try:
-                if type(l) == str:
+                if isinstance(l, str):
                     color = "#" + hashlib.sha224(l.encode()).hexdigest()[2:8]
                     plt.text(xv, yv, l, fontsize=13, color=color)
                 else:

--- a/tests/test_prtecan.py
+++ b/tests/test_prtecan.py
@@ -74,7 +74,7 @@ def test__merge_md() -> None:
         "Gain": prtecan.Metadata(93, ["Optimal"]),
         "Shaking (Linear) Amplitude:": prtecan.Metadata(2, ["mm"]),
     }
-    mmd = prtecan._merge_md([md1, md2])
+    mmd = prtecan.merge_md([md1, md2])
     assert mmd["Gain"] == prtecan.Metadata(93)
     assert mmd["Shaking (Linear) Amplitude:"] == prtecan.Metadata(2, ["mm"])
 

--- a/tests/test_prtecan.py
+++ b/tests/test_prtecan.py
@@ -16,6 +16,23 @@ from clophfit import prtecan
 data_tests = Path(__file__).parent / "Tecan"
 
 
+def test_lookup_listoflines() -> None:
+    """It returns indexes for pattern match on col in list of lines."""
+    csvl: list[list[str | int | float]] = [
+        ["pp", "xy", 1, 2.0],
+        ["pp", "xx", 1, 2],
+        ["pp", 12, 1, 2],
+        ["pp", "yy", 1, 2.0],
+        ["a"],
+        ["pp", "xy", 1, 2],
+    ]
+    assert prtecan.lookup_listoflines(csvl, pattern="pp") == [0, 1, 2, 3, 5]
+    assert prtecan.lookup_listoflines(csvl, pattern="xy") == []
+    assert prtecan.lookup_listoflines(csvl, pattern="xy", col=1) == [0, 5]
+    assert prtecan.lookup_listoflines(csvl, pattern="yy", col=1) == [3]
+    assert prtecan.lookup_listoflines(csvl, pattern="yy", col=2) == []
+
+
 def test_strip_lines() -> None:
     """It strips empty fields."""
     lines: list[list[float | int | str]] = [
@@ -215,7 +232,7 @@ class TestTecanfile:
         assert len(self.csvl) == 74
 
     def test_lookup_listoflines(self) -> None:
-        """It finds Label occurrences using cls method."""
+        """It finds Label occurrences using module function."""
         assert prtecan.lookup_listoflines(self.csvl) == [14, 44]
 
     def test_labelblocks(self) -> None:

--- a/tests/test_prtecan.py
+++ b/tests/test_prtecan.py
@@ -64,7 +64,7 @@ def test_extract_metadata() -> None:
     assert metadata == expected_metadata
 
 
-def test__merge_md() -> None:
+def test_merge_md() -> None:
     """Merge metadata of both labelblocks and tecanfiles."""
     md1 = {
         "Gain": prtecan.Metadata(93, ["Manual"]),

--- a/tests/test_prtecan.py
+++ b/tests/test_prtecan.py
@@ -288,6 +288,7 @@ class TestLabelblocksGroup:
         lbg2 = prtecan.LabelblocksGroup([tfs[1].labelblocks[1], tfs[2].labelblocks[1]])
         lbg1.buffer_wells = ["C12", "D01", "D12", "E01", "E12", "F01"]
         lbg2.buffer_wells = ["C12", "D01", "D12", "E01", "E12", "F01"]
+        # pylint: disable=W0201
         self.lbg0 = lbg1
         self.lbg1 = lbg2
 


### PR DESCRIPTION
- refactor: follow pylint
- refactor: listoflines lookup
- chore: (attribute-defined-outside-init)
- refactor: src
- fix: lint with 3.10 avoid removal of tomli and exceptiongroup deps
- refactor: pylint tests
- refactor: pylint tests 10/10
- style: rename a test function
- test: refactoring too complex fixtures
- test: refactor too complex fixtures
- test: refactor too complex fixtures
