### PR TITLE
Unify residual schema + add fr.residuals entry point

### DIFF
--- a/src/clophfit/clophfit_types.py
+++ b/src/clophfit/clophfit_types.py
@@ -3,11 +3,21 @@
 from collections.abc import Callable, Mapping
 
 import numpy as np
+import odrpack
+import xarray as xr
+from lmfit.minimizer import Minimizer  # type: ignore[import-untyped]
 from numpy.typing import NDArray
 
 # Array types
 ArrayF = NDArray[np.float64]  # Generic float64 array
 ArrayMask = NDArray[np.bool_]
+
+# Minimizer/backend result union shared across fitting modules.
+# Defined here (a dependency-light leaf module) rather than in
+# ``fitting.data_structures`` so it is never pulled into the fitting-package
+# import cycle, which would otherwise demote this implicit alias to a plain
+# variable in mypy's eyes (``MiniT is not valid as a type``).
+MiniT = Minimizer | odrpack.OdrResult | xr.DataTree
 
 # Dictionary types
 ArrayDict = dict[

--- a/src/clophfit/fitting/bayes.py
+++ b/src/clophfit/fitting/bayes.py
@@ -1728,7 +1728,7 @@ _DEFAULT_INIT = InitConfig()
 _DEFAULT_SAMPLER = SamplerConfig()
 
 
-def fit_binding_pymc(  # noqa: PLR0913, PLR0915
+def fit_binding_pymc(  # noqa: PLR0912, PLR0913, PLR0915
     ds_or_fr: Dataset | FitResult[MiniT],
     *,
     n_sd: float = 10.0,
@@ -1924,6 +1924,8 @@ def fit_binding_pymc(  # noqa: PLR0913, PLR0915
         }
         if sampler.max_treedepth is not None:
             sample_kwargs["max_treedepth"] = sampler.max_treedepth
+        if sampler.random_seed is not None:
+            sample_kwargs["random_seed"] = sampler.random_seed
         trace = pm.sample(n_samples, **sample_kwargs)
         trace = _compute_sample_log_likelihood(trace)
     p_names = list(params.keys())

--- a/src/clophfit/fitting/bayes_config.py
+++ b/src/clophfit/fitting/bayes_config.py
@@ -80,6 +80,9 @@ class SamplerConfig:
         default.
     max_treedepth : int | None
         Maximum NUTS tree depth. ``None`` uses the backend default.
+    random_seed : int | None
+        Seed forwarded to ``pm.sample`` for reproducible draws. ``None`` (the
+        default) leaves sampling nondeterministic.
     """
 
     n_samples: int = 2000
@@ -87,6 +90,7 @@ class SamplerConfig:
     n_tune: int | None = None
     target_accept: float | None = None
     max_treedepth: int | None = None
+    random_seed: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/clophfit/fitting/data_structures.py
+++ b/src/clophfit/fitting/data_structures.py
@@ -13,6 +13,7 @@ import copy
 import warnings
 from collections import UserDict
 from dataclasses import dataclass, field
+from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, TypeVar, cast, runtime_checkable
 
@@ -27,6 +28,8 @@ from uncertainties import ufloat  # type: ignore[import-untyped]
 from .errors import InvalidDataError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from lmfit import Parameters  # type: ignore[import-untyped]
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
@@ -471,6 +474,68 @@ class FitResult[MiniType: MiniProtocol]:
             and self.mini is not None
         )
 
+    @cached_property
+    def residuals(self) -> pd.DataFrame:
+        """Canonical per-observation residual table for this fit.
+
+        Lazily computed, cached, and returned in the schema shared across the
+        package (``clophfit.fitting.model_validation.RESIDUAL_TABLE_COLUMNS``:
+        ``raw_res``, ``that``, ``sigma``, ``std_res``, …). Works for both LMFit
+        and PyMC fits; robustness is auto-detected from the trace. Use
+        :meth:`residual_table` to override the model or robust settings.
+        """
+        return self.residual_table()
+
+    def residual_table(
+        self,
+        *,
+        binding_function: Callable[..., object] | None = None,
+        robust: bool | None = None,
+        student_t_nu: float | None = None,
+        outlier_threshold: float = 3.0,
+        well: str = "",
+    ) -> pd.DataFrame:
+        """Compute the canonical residual table with explicit settings.
+
+        Parameters
+        ----------
+        binding_function : Callable[..., object] | None
+            Model to evaluate the prediction; defaults to ``binding_1site``.
+        robust : bool | None
+            Force the robust standardization of ``std_res``. ``None``
+            auto-detects from the trace.
+        student_t_nu : float | None
+            Student-t degrees of freedom for the robust score. ``None`` uses the
+            detected/default value.
+        outlier_threshold : float
+            Threshold for the ``is_residual_outlier`` flag.
+        well : str
+            Value placed in the ``well`` column (single-fit label).
+
+        Returns
+        -------
+        pd.DataFrame
+            The canonical residual table (see :attr:`residuals`).
+        """
+        from clophfit.fitting import model_validation  # noqa: PLC0415
+        from clophfit.fitting.models import binding_1site  # noqa: PLC0415
+
+        bfunc = binding_1site if binding_function is None else binding_function
+        if robust is None:
+            robust, detected_nu = model_validation.robust_settings_from_trace(self.mini)
+            if student_t_nu is None:
+                student_t_nu = detected_nu
+        if student_t_nu is None:
+            student_t_nu = model_validation.STUDENT_T_NU
+        return model_validation.residuals_from_fit_results(
+            {well: self},
+            trace_id="",
+            binding_function=bfunc,
+            robust=robust,
+            student_t_nu=student_t_nu,
+            outlier_threshold=outlier_threshold,
+        )
+
 
 @dataclass
 class MultiFitResult:
@@ -490,6 +555,64 @@ class MultiFitResult:
     def __getattr__(self, name: str) -> object:
         """Delegate trace attributes for convenient compatibility."""
         return getattr(self.trace, name)
+
+    @cached_property
+    def residuals(self) -> pd.DataFrame:
+        """Canonical per-observation residual table across all wells.
+
+        Lazily computed, cached, and returned in the shared schema
+        (``RESIDUAL_TABLE_COLUMNS``, including ``p_outlier_per_point`` extracted
+        from the trace). Robustness is auto-detected; use :meth:`residual_table`
+        to override.
+        """
+        return self.residual_table()
+
+    def residual_table(
+        self,
+        *,
+        binding_function: Callable[..., object] | None = None,
+        robust: bool | None = None,
+        student_t_nu: float | None = None,
+        outlier_threshold: float = 3.0,
+    ) -> pd.DataFrame:
+        """Compute the canonical multi-well residual table with explicit settings.
+
+        Parameters
+        ----------
+        binding_function : Callable[..., object] | None
+            Model to evaluate; defaults to ``binding_1site``.
+        robust : bool | None
+            Force robust standardization of ``std_res`` (``None`` auto-detects).
+        student_t_nu : float | None
+            Student-t degrees of freedom (``None`` uses detected/default).
+        outlier_threshold : float
+            Threshold for the ``is_residual_outlier`` flag.
+
+        Returns
+        -------
+        pd.DataFrame
+            The canonical residual table (see :attr:`residuals`).
+        """
+        from clophfit.fitting import model_validation  # noqa: PLC0415
+        from clophfit.fitting.models import binding_1site  # noqa: PLC0415
+
+        bfunc = binding_1site if binding_function is None else binding_function
+        if robust is None:
+            robust, detected_nu = model_validation.robust_settings_from_trace(
+                self.trace
+            )
+            if student_t_nu is None:
+                student_t_nu = detected_nu
+        if student_t_nu is None:
+            student_t_nu = model_validation.STUDENT_T_NU
+        return model_validation.residuals_from_multifit(
+            self,
+            trace_id="",
+            binding_function=bfunc,
+            robust=robust,
+            student_t_nu=student_t_nu,
+            outlier_threshold=outlier_threshold,
+        )
 
 
 @dataclass

--- a/src/clophfit/fitting/data_structures.py
+++ b/src/clophfit/fitting/data_structures.py
@@ -19,18 +19,24 @@ from typing import TYPE_CHECKING, Protocol, TypeVar, cast, runtime_checkable
 
 import matplotlib.pyplot as plt
 import numpy as np
-import odrpack
 import pandas as pd
-import xarray as xr
-from lmfit.minimizer import Minimizer, MinimizerResult  # type: ignore[import-untyped]
 from uncertainties import ufloat  # type: ignore[import-untyped]
+
+# Re-exported for back-compat: MiniT lives in the leaf ``clophfit_types`` module
+# so it stays out of the fitting-package import cycle (see its definition there).
+from clophfit.clophfit_types import MiniT as MiniT  # noqa: PLC0414
 
 from .errors import InvalidDataError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import xarray as xr
     from lmfit import Parameters  # type: ignore[import-untyped]
+    from lmfit.minimizer import (  # type: ignore[import-untyped]
+        Minimizer,
+        MinimizerResult,
+    )
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
 
@@ -435,7 +441,6 @@ class MiniProtocol(Protocol):
 
 
 MiniType = TypeVar("MiniType", bound=MiniProtocol)
-MiniT = Minimizer | odrpack.OdrResult | xr.DataTree
 
 
 @dataclass

--- a/src/clophfit/fitting/model_validation.py
+++ b/src/clophfit/fitting/model_validation.py
@@ -28,6 +28,7 @@ RESIDUAL_TABLE_COLUMNS = [
     "well",
     "label",
     "step",
+    "raw_i",
     "x",
     "y",
     "that",
@@ -805,6 +806,45 @@ def _posterior_dataset_or_none(trace: _t.Any) -> _t.Any | None:
         return None
 
 
+def robust_settings_from_trace(trace: _t.Any) -> tuple[bool, float]:
+    """Infer ``(robust, student_t_nu)`` from a trace's posterior variables.
+
+    Detects an inferred Student-t (a ``student_t_nu`` deterministic) or a
+    contamination mixture (``pi_outlier_*`` / ``outlier_inflate``). Used by
+    ``FitResult.residuals`` / ``MultiFitResult.residuals`` so the residual table
+    is standardized correctly without the caller re-supplying fit settings.
+
+    Parameters
+    ----------
+    trace : _t.Any
+        A PyMC trace (``xr.DataTree``) or ``None`` for classical fits.
+
+    Returns
+    -------
+    tuple[bool, float]
+        Whether a robust likelihood was used and the Student-t nu to apply.
+
+    Notes
+    -----
+    A *fixed*-nu Student-t leaves no trace marker and is reported as non-robust;
+    only the Normal-score transform of ``std_res`` differs (``raw_res``/``that``/
+    ``likelihood_res`` are unaffected). Pass ``robust=`` to
+    ``residual_table`` to override.
+    """
+    post = _posterior_dataset_or_none(trace)
+    if post is None:
+        return False, STUDENT_T_NU
+    names = {str(n) for n in getattr(post, "data_vars", {})}
+    if any(n.startswith("pi_outlier") for n in names) or "outlier_inflate" in names:
+        return True, STUDENT_T_NU
+    if "student_t_nu" in names:
+        try:
+            return True, float(post["student_t_nu"].mean())
+        except Exception:
+            return True, STUDENT_T_NU
+    return False, STUDENT_T_NU
+
+
 def _fit_result_labels(fit: _t.Any) -> tuple[str, ...]:
     dataset = getattr(fit, "dataset", None)
     if dataset is None:
@@ -1344,6 +1384,7 @@ def residuals_from_multifit(  # noqa: PLR0913
                     "well": str(well),
                     "label": str(lbl),
                     "step": int(step[j]),
+                    "raw_i": int(step[j]),
                     "x": float(x[j]),
                     "y": float(y[j]),
                     "that": float(that[j]),
@@ -1424,6 +1465,7 @@ def residuals_from_fit_results(  # noqa: PLR0913
                     "well": str(well),
                     "label": str(lbl),
                     "step": int(step[j]) if j < len(step) else int(j),
+                    "raw_i": int(step[j]) if j < len(step) else int(j),
                     "x": float(x[j]),
                     "y": float(y[j]),
                     "that": float(that[j]),

--- a/src/clophfit/fitting/model_validation.py
+++ b/src/clophfit/fitting/model_validation.py
@@ -46,7 +46,26 @@ RESIDUAL_TABLE_COLUMNS = [
 
 @dataclass
 class ResidualDiagnostics:
-    """Convenience wrapper for repeated residual diagnostics."""
+    """Single fluent home for residual analysis over a canonical residual table.
+
+    Build one from a fit (``ResidualDiagnostics.from_fit_results(...)``) or wrap
+    an existing table (``ResidualDiagnostics(fr.residuals)``), then chain
+    transforms and read summaries. This is the place to reach for residual
+    analysis; the module-level ``residual_*`` functions are its building blocks.
+
+    Transforms (return a new ``ResidualDiagnostics``): :meth:`annotate`,
+    :meth:`step_centered`, :meth:`label_scaled`, :meth:`well_scaled`,
+    :meth:`with_relative_residuals`.
+
+    Summaries / analyses (return frames): :meth:`well_summary`,
+    :meth:`normality`, :meth:`step_summary`, :meth:`position_summary`,
+    :meth:`tail_rows`, :meth:`distribution_summary`, :meth:`x_correlation`,
+    :meth:`lag1_autocorrelation`. Further building blocks are the module-level
+    ``residual_x_trend_summary`` / ``residual_cross_label_correlation``.
+
+    Plots: :meth:`plot_hist_qq`, :meth:`plot_step`, :meth:`plot_role`,
+    :meth:`plot_col`, :meth:`plot_well_summary`.
+    """
 
     residuals: pd.DataFrame
     value_col: str = "std_res"
@@ -238,6 +257,34 @@ class ResidualDiagnostics:
                 "skew",
             ])
         return out
+
+    # -- Distribution / trend / correlation analyses (delegate to the free
+    #    functions below, all on the ``std_res`` column). Grouped here so the
+    #    diagnostics object is the single place to reach for residual analysis.
+    def distribution_summary(self) -> pd.DataFrame:
+        """Per-(trace, label) residual distribution stats.
+
+        See :func:`residual_distribution_summary`. Supersedes
+        :func:`clophfit.fitting.residuals.residual_statistics`.
+        """
+        return residual_distribution_summary(self.residuals)
+
+    def x_correlation(self) -> pd.DataFrame:
+        """Pearson/Spearman correlation of residuals against x.
+
+        See :func:`residual_x_correlation`. Relates to
+        :func:`clophfit.fitting.residuals.estimate_x_shift_statistics`;
+        :func:`residual_x_trend_summary` gives the by-step trend.
+        """
+        return residual_x_correlation(self.residuals)
+
+    def lag1_autocorrelation(self) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Lag-1 residual autocorrelation per well and its per-label summary.
+
+        See :func:`residual_lag1_autocorrelation`. Supersedes
+        :func:`clophfit.fitting.residuals.detect_adjacent_correlation`.
+        """
+        return residual_lag1_autocorrelation(self.residuals)
 
     def tail_rows(self, n: int = 30, *, column: str | None = None) -> pd.DataFrame:
         """Return rows with largest absolute residual values."""

--- a/src/clophfit/fitting/pipeline.py
+++ b/src/clophfit/fitting/pipeline.py
@@ -3,6 +3,8 @@
 import logging
 import typing
 
+import pandas as pd
+
 from clophfit.fitting.bayes import fit_binding_pymc
 from clophfit.fitting.core import fit_binding_glob
 from clophfit.fitting.data_structures import (
@@ -16,8 +18,10 @@ from clophfit.fitting.odr import fit_binding_odr
 from clophfit.fitting.residuals import collect_multi_residuals
 from clophfit.fitting.utils import (
     compute_plate_slopes,
+    fit_gain_from_residuals,
     fit_noise_model_nnls,
     fit_ph_slope_noise,
+    fit_rel_error_from_residuals,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,6 +61,60 @@ def _plate_noise_model_from_nnls(
             sigma_ph=sigma_ph,
         )
     return model
+
+
+def calibrate_noise_robust(
+    residuals: pd.DataFrame,
+    sigma_floor: dict[str, float],
+    *,
+    p_threshold: float = 0.9,
+    min_keep: int = 3,
+) -> PlateNoiseModel:
+    """Calibrate a per-label noise model from outlier-screened residuals.
+
+    Drops points whose posterior outlier probability exceeds *p_threshold*
+    (from a PyMC mixture fit) and then estimates ``gain`` and ``alpha`` per
+    label with the single-term moment estimators
+    (:func:`~clophfit.fitting.utils.fit_gain_from_residuals`,
+    :func:`~clophfit.fitting.utils.fit_rel_error_from_residuals`) on the
+    retained points. Screening with the mixture's ``p_outlier_per_point`` keeps
+    outliers from inflating the estimate, while the two single-term estimators
+    avoid the gain/alpha collinearity of the joint NNLS over narrow titration
+    ranges.
+
+    Parameters
+    ----------
+    residuals : pd.DataFrame
+        Canonical residual table (e.g. ``MultiFitResult.residuals`` from a
+        mixture fit). Must have ``label``, ``raw_res``, ``that`` columns; a
+        ``p_outlier_per_point`` column enables screening (otherwise all points
+        are used).
+    sigma_floor : dict[str, float]
+        Known read-noise floor per label, e.g. ``tit.bg_noise``. Used as the
+        fixed floor and copied into the returned model.
+    p_threshold : float, optional
+        Posterior outlier probability above which a point is dropped.
+    min_keep : int, optional
+        Per label, if screening would retain fewer than this many points the
+        full (unscreened) set is used instead.
+
+    Returns
+    -------
+    PlateNoiseModel
+        Per-label model with ``sigma_floor`` from *sigma_floor* and calibrated
+        ``gain``/``alpha``.
+    """
+    if "p_outlier_per_point" in residuals.columns:
+        kept: list[pd.DataFrame] = []
+        for _label, group in residuals.groupby("label", observed=True):
+            inliers = group[group["p_outlier_per_point"].fillna(0.0) < p_threshold]
+            kept.append(group if len(inliers) < min_keep else inliers)
+        clean = pd.concat(kept, ignore_index=True) if kept else residuals
+    else:
+        clean = residuals
+    gains = fit_gain_from_residuals(clean, sigma_floor)
+    alphas = fit_rel_error_from_residuals(clean, sigma_floor)
+    return _plate_noise_model_from_nnls(dict(sigma_floor), gains, alphas)
 
 
 def fgls_plate_fit(  # noqa: PLR0913

--- a/src/clophfit/fitting/residuals.py
+++ b/src/clophfit/fitting/residuals.py
@@ -46,25 +46,37 @@ class ResidualPoint:
         Dataset label (e.g., '1', '2' for multi-label fits)
     x : float
         X-value (pH or ligand concentration)
-    resid_weighted : float
-        Weighted residual: (y - model) / y_err
-    resid_raw : float
-        Raw residual: (y - model)
+    y : float
+        Observed signal value.
+    that : float
+        Model-predicted signal value (``y - raw_res``).
+    sigma : float
+        Measurement uncertainty used during fitting.
+    raw_res : float
+        Raw residual: ``y - that``.
+    likelihood_res : float
+        Likelihood-scale residual: ``(y - that) / sigma``.
+    std_res : float
+        Normal-scale standardized residual (equal to *likelihood_res* for a
+        Normal likelihood, as produced by LMFit/ODR fits).
     raw_i : int
         Index into the original (unmasked) arrays for this label (`DataArray.xc/yc`).
-    y_err : float
-        Measurement uncertainty used during fitting.
-    predicted : float
-        Model-predicted signal value (y - resid_raw).
+
+    Notes
+    -----
+    Field names follow the canonical residual-table schema shared with
+    :data:`clophfit.fitting.model_validation.RESIDUAL_TABLE_COLUMNS`.
     """
 
     label: str
     x: float
-    resid_weighted: float
-    resid_raw: float
+    y: float
+    that: float
+    sigma: float
+    raw_res: float
+    likelihood_res: float
+    std_res: float
     raw_i: int
-    y_err: float
-    predicted: float
 
 
 def extract_residual_points(fr: FitResult[Any]) -> list[ResidualPoint]:
@@ -138,11 +150,13 @@ def extract_residual_points(fr: FitResult[Any]) -> list[ResidualPoint]:
             ResidualPoint(
                 label=lbl,
                 x=float(xs[i]),
-                resid_weighted=float(rw[i]),
-                resid_raw=float(rr[i]),
+                y=float(ys[i]),
+                that=float(ys[i]) - float(rr[i]),
+                sigma=float(y_err[i]),
+                raw_res=float(rr[i]),
+                likelihood_res=float(rw[i]),
+                std_res=float(rw[i]),
                 raw_i=int(raw_is[i]),
-                y_err=float(y_err[i]),
-                predicted=float(ys[i]) - float(rr[i]),
             )
             for i in range(len(rw))
         )
@@ -165,7 +179,8 @@ def residual_dataframe(fr: FitResult[Any]) -> pd.DataFrame:
     Returns
     -------
     pd.DataFrame
-        DataFrame with columns: label, x, resid_weighted, resid_raw, raw_i, y_err, predicted
+        DataFrame with the canonical residual columns: label, x, y, that,
+        sigma, raw_res, likelihood_res, std_res, raw_i.
 
     Examples
     --------
@@ -201,7 +216,8 @@ def collect_multi_residuals(
     Returns
     -------
     pd.DataFrame
-        Combined DataFrame with columns: well, label, x, resid_weighted, resid_raw, raw_i
+        Combined DataFrame with the canonical residual columns plus ``well``:
+        well, label, x, y, that, sigma, raw_res, likelihood_res, std_res, raw_i.
 
     Examples
     --------
@@ -266,7 +282,7 @@ def residual_statistics(df: pd.DataFrame) -> pd.DataFrame:
         return int((np.abs(x) > OUTLIER_THRESHOLD_2SIGMA).sum())
 
     # Use dict format for agg to avoid mypy issues with tuple format
-    summary = df.groupby("label")["resid_weighted"].agg(
+    summary = df.groupby("label")["std_res"].agg(
         mean="mean",
         std="std",
         median="median",
@@ -330,7 +346,7 @@ def validate_residuals(fr: FitResult[Any], *, verbose: bool = True) -> dict[str,
 
     # Check 1: Systematic bias (t-test against 0) per label
     for lbl, group in df.groupby("label"):
-        r_lbl = group["resid_weighted"].to_numpy()
+        r_lbl = group["std_res"].to_numpy()
         if len(r_lbl) > 1:
             _t_stat, p_value = sp_stats.ttest_1samp(r_lbl, 0)
             if p_value < BIAS_P_VALUE_THRESHOLD:
@@ -341,7 +357,7 @@ def validate_residuals(fr: FitResult[Any], *, verbose: bool = True) -> dict[str,
                     )
 
     # Check 2: Outliers (more than 5% beyond ±2-sigma)
-    r_all = df["resid_weighted"].to_numpy()
+    r_all = df["std_res"].to_numpy()
     outlier_rate = (np.abs(r_all) > OUTLIER_THRESHOLD_2SIGMA).mean()
     checks["outliers_ok"] = bool(outlier_rate < OUTLIER_RATE_THRESHOLD)
     if not checks["outliers_ok"] and verbose:
@@ -353,7 +369,7 @@ def validate_residuals(fr: FitResult[Any], *, verbose: bool = True) -> dict[str,
     for _lbl, group in df.groupby("label"):
         # Sort by x to ensure temporal/spatial adjacent ordering is correct
         g_sorted = group.sort_values("x")
-        r_lbl = g_sorted["resid_weighted"].to_numpy()
+        r_lbl = g_sorted["std_res"].to_numpy()
         if len(r_lbl) > 1:
             ss_diff += np.sum(np.diff(r_lbl) ** 2)
             ss_total += np.sum(r_lbl**2)
@@ -370,7 +386,7 @@ def validate_residuals(fr: FitResult[Any], *, verbose: bool = True) -> dict[str,
 
 
 def compute_residual_covariance(
-    all_res: pd.DataFrame, value_col: str = "resid_weighted"
+    all_res: pd.DataFrame, value_col: str = "std_res"
 ) -> dict[str, pd.DataFrame]:
     """Compute covariance matrix of residuals for each label."""
     cov_by_label: dict[str, pd.DataFrame] = {}
@@ -416,25 +432,25 @@ def analyze_label_bias(
     all_res = all_res.copy()
     all_res["x_bin"] = pd.cut(all_res["x"], bins=n_bins)
 
-    mean_resid = all_res["resid_weighted"].mean()
-    std_resid = all_res["resid_weighted"].std()
-    all_res["std_res"] = (all_res["resid_weighted"] - mean_resid) / std_resid
+    mean_resid = all_res["std_res"].mean()
+    std_resid = all_res["std_res"].std()
+    all_res["std_res"] = (all_res["std_res"] - mean_resid) / std_resid
 
     bias_summary = all_res.groupby(["label", "x_bin"], observed=False).agg(
-        mean_resid=("resid_weighted", "mean"),
-        std_resid=("resid_weighted", "std"),
-        count=("resid_weighted", "count"),
+        mean_resid=("std_res", "mean"),
+        std_resid=("std_res", "std"),
+        count=("std_res", "count"),
         outlier_rate=("std_res", lambda x: (np.abs(x) > outlier_threshold).mean()),
         mean_std_res=("std_res", "mean"),
     )
 
     label_bias = all_res.groupby("label", observed=False).agg(
-        mean_resid=("resid_weighted", "mean"),
-        std_resid=("resid_weighted", "std"),
-        median_resid=("resid_weighted", "median"),
+        mean_resid=("std_res", "mean"),
+        std_resid=("std_res", "std"),
+        median_resid=("std_res", "median"),
         outlier_rate=("std_res", lambda x: (np.abs(x) > outlier_threshold).mean()),
         negative_bias_frac=(
-            "resid_weighted",
+            "std_res",
             lambda x: (x < strong_negative_threshold).mean(),
         ),
     )
@@ -451,7 +467,7 @@ def detect_adjacent_correlation(
 
     for (lbl, well), group in all_res.groupby(["label", "well"]):
         g = group.sort_values("x")
-        res = g["resid_weighted"].to_numpy()
+        res = g["std_res"].to_numpy()
 
         if len(res) > 1:
             corr = np.corrcoef(res[:-1], res[1:])[0, 1]
@@ -484,7 +500,7 @@ def estimate_x_shift_statistics(
 
         if len(sorted_group) > MIN_POINTS_FOR_TREND:
             x_vals = sorted_group["x"].to_numpy()
-            res_vals = sorted_group["resid_weighted"].to_numpy()
+            res_vals = sorted_group["std_res"].to_numpy()
 
             try:
                 slope, intercept = np.polyfit(x_vals, res_vals, 1)
@@ -520,7 +536,7 @@ def plot_residual_vs_predicted(all_res: pd.DataFrame, title: str = "") -> Figure
     ----------
     all_res : pd.DataFrame
         Residual DataFrame from ``collect_multi_residuals``.  Must contain
-        columns ``label``, ``predicted``, and ``resid_weighted``.
+        columns ``label``, ``that``, and ``std_res``.
     title : str, optional
         Figure suptitle suffix.
 
@@ -536,8 +552,8 @@ def plot_residual_vs_predicted(all_res: pd.DataFrame, title: str = "") -> Figure
 
     for ax, label in zip(axes[0], labels, strict=False):
         grp = all_res[all_res["label"] == label]
-        pred = grp["predicted"].to_numpy(dtype=float)
-        std_res = grp["resid_weighted"].to_numpy(dtype=float)
+        pred = grp["that"].to_numpy(dtype=float)
+        std_res = grp["std_res"].to_numpy(dtype=float)
         ax.scatter(pred, np.abs(std_res), s=8, alpha=0.3, color="C0")
 
         valid = np.isfinite(pred) & np.isfinite(std_res)
@@ -583,7 +599,7 @@ def plot_residual_vs_yerr(all_res: pd.DataFrame, title: str = "") -> Figure:
     ----------
     all_res : pd.DataFrame
         Residual DataFrame from ``collect_multi_residuals``.  Must contain
-        columns ``label``, ``y_err``, and ``resid_raw``.
+        columns ``label``, ``sigma``, and ``raw_res``.
     title : str, optional
         Figure suptitle suffix.
 
@@ -599,8 +615,8 @@ def plot_residual_vs_yerr(all_res: pd.DataFrame, title: str = "") -> Figure:
 
     for ax, label in zip(axes[0], labels, strict=False):
         grp = all_res[all_res["label"] == label]
-        y_err = grp["y_err"].to_numpy(dtype=float)
-        raw_res = grp["resid_raw"].to_numpy(dtype=float)
+        y_err = grp["sigma"].to_numpy(dtype=float)
+        raw_res = grp["raw_res"].to_numpy(dtype=float)
         valid = np.isfinite(y_err) & np.isfinite(raw_res) & (y_err > 0)
         ye_v, rr_v = y_err[valid], raw_res[valid]
 

--- a/src/clophfit/fitting/utils.py
+++ b/src/clophfit/fitting/utils.py
@@ -353,8 +353,8 @@ def fit_rel_error_from_residuals(
     Parameters
     ----------
     df : pd.DataFrame
-        DataFrame with columns ``label`` (str), ``resid_raw`` (float), and
-        ``predicted`` (float -- the model-predicted signal at each point).
+        DataFrame with columns ``label`` (str), ``raw_res`` (float), and
+        ``that`` (float -- the model-predicted signal at each point).
         Typically from :func:`clophfit.fitting.residuals.collect_multi_residuals`.
     sigma_floor : dict[str, float]
         Known read-noise floor per label, e.g. from ``tit.bg_noise``.
@@ -372,7 +372,7 @@ def fit_rel_error_from_residuals(
     >>> floor, true_alpha = 5.0, 0.02
     >>> sigma = np.sqrt(floor**2 + (true_alpha * y_pred) ** 2)
     >>> resid = sigma * rng.standard_normal(200)
-    >>> df = pd.DataFrame({"label": "1", "resid_raw": resid, "predicted": y_pred})
+    >>> df = pd.DataFrame({"label": "1", "raw_res": resid, "that": y_pred})
     >>> alpha = fit_rel_error_from_residuals(df, sigma_floor={"1": floor})
     >>> round(alpha["1"], 2)  # should be close to true_alpha=0.02
     0.02
@@ -380,8 +380,8 @@ def fit_rel_error_from_residuals(
     result: dict[str, float] = {}
     for lbl, grp in df.groupby("label"):
         lbl_str = str(lbl)
-        r2_mean = float((grp["resid_raw"] ** 2).mean())
-        pred2_mean = float((grp["predicted"] ** 2).mean())
+        r2_mean = float((grp["raw_res"] ** 2).mean())
+        pred2_mean = float((grp["that"] ** 2).mean())
         floor = float(sigma_floor.get(lbl_str, 0.0))
         alpha_sq = max(0.0, r2_mean - floor**2) / max(pred2_mean, 1e-12)
         result[lbl_str] = float(np.sqrt(alpha_sq))
@@ -408,8 +408,8 @@ def fit_gain_from_residuals(
     Parameters
     ----------
     df : pd.DataFrame
-        DataFrame with columns ``label`` (str), ``resid_raw`` (float), and
-        ``predicted`` (float -- the model-predicted signal at each point).
+        DataFrame with columns ``label`` (str), ``raw_res`` (float), and
+        ``that`` (float -- the model-predicted signal at each point).
         Typically from :func:`clophfit.fitting.residuals.collect_multi_residuals`.
     sigma_floor : dict[str, float]
         Known read-noise floor per label, e.g. from ``tit.bg_noise``.
@@ -427,7 +427,7 @@ def fit_gain_from_residuals(
     >>> floor, true_gain = 5.0, 0.8
     >>> sigma = np.sqrt(floor**2 + true_gain * y_pred)
     >>> resid = sigma * rng.standard_normal(400)
-    >>> df = pd.DataFrame({"label": "1", "resid_raw": resid, "predicted": y_pred})
+    >>> df = pd.DataFrame({"label": "1", "raw_res": resid, "that": y_pred})
     >>> gain = fit_gain_from_residuals(df, sigma_floor={"1": floor})
     >>> round(gain["1"], 1)  # should be close to true_gain=0.8
     0.8
@@ -435,8 +435,8 @@ def fit_gain_from_residuals(
     result: dict[str, float] = {}
     for lbl, grp in df.groupby("label"):
         lbl_str = str(lbl)
-        r2_mean = float((grp["resid_raw"] ** 2).mean())
-        pred_mean = float(grp["predicted"].mean())
+        r2_mean = float((grp["raw_res"] ** 2).mean())
+        pred_mean = float(grp["that"].mean())
         floor = float(sigma_floor.get(lbl_str, 0.0))
         gain = max(0.0, r2_mean - floor**2) / max(pred_mean, 1e-12)
         result[lbl_str] = float(gain)
@@ -460,7 +460,7 @@ def fit_noise_model_nnls(
     Parameters
     ----------
     df : pd.DataFrame
-        Residual DataFrame with columns ``label``, ``resid_raw``, ``predicted``.
+        Residual DataFrame with columns ``label``, ``raw_res``, ``that``.
     sigma_floor_fixed : dict[str, float] | None
         If given, fix floor per label and only fit gain and alpha.
     rel_error_fixed : dict[str, float] | None
@@ -486,8 +486,8 @@ def fit_noise_model_nnls(
 
     for lbl, grp in df.groupby("label"):
         lbl_str = str(lbl)
-        y = grp["predicted"].to_numpy().astype(float)
-        r2 = grp["resid_raw"].to_numpy().astype(float) ** 2
+        y = grp["that"].to_numpy().astype(float)
+        r2 = grp["raw_res"].to_numpy().astype(float) ** 2
 
         if sigma_floor_fixed is not None:
             floor = sigma_floor_fixed.get(lbl_str, 0.0)
@@ -593,8 +593,8 @@ def fit_ph_slope_noise(
     Parameters
     ----------
     df : pd.DataFrame
-        Residual DataFrame with columns ``label``, ``well``, ``resid_raw``,
-        ``predicted``, and ``raw_i``.
+        Residual DataFrame with columns ``label``, ``well``, ``raw_res``,
+        ``that``, and ``raw_i``.
     noise_model : PlateNoiseModel
         Per-label noise model (floor, gain, alpha) fitted in the same pass.
     plate_slopes : dict[str, dict[str, np.ndarray]]
@@ -611,12 +611,12 @@ def fit_ph_slope_noise(
         params = noise_model[str(lbl)]
         mask = df["label"] == lbl
         df.loc[mask, "var_model"] = compute_noise_variance(
-            df.loc[mask, "predicted"].to_numpy(dtype=float),
+            df.loc[mask, "that"].to_numpy(dtype=float),
             params.sigma_floor,
             params.gain,
             params.alpha,
         )
-    df["var_excess"] = df["resid_raw"] ** 2 - df["var_model"]
+    df["var_excess"] = df["raw_res"] ** 2 - df["var_model"]
     df["slope_sq"] = np.nan
     for (lbl, well), grp in df.groupby(["label", "well"]):
         w_slopes_dict = plate_slopes.get(str(well))

--- a/tests/test_bayesian_x_error.py
+++ b/tests/test_bayesian_x_error.py
@@ -63,16 +63,22 @@ def test_fit_binding_pymc_x_error_adjustment() -> None:
     fr: FitResult[_Result] = FitResult(dataset=ds, result=_Result(params))
 
     # 2. Run Bayesian Fit with x-error modeling
-    # n_xerr=1.0 enables x_true modeling
+    # n_xerr=1.0 enables x_true modeling. The x-true shift competes with the
+    # per-sample y-error scale (``ye_mag``), so the effect on x_true[2] is small
+    # (order 0.02 pH). Fix ``random_seed`` for reproducible draws, and use enough
+    # of them that the Monte-Carlo error on the posterior mean (~sd/sqrt(ESS)) is
+    # well below that shift; otherwise the boundary check below flips sign.
     fit_res = bayes.fit_binding_pymc(
-        fr, n_xerr=1.0, sampler=SamplerConfig(n_samples=500)
+        fr, n_xerr=1.0, sampler=SamplerConfig(n_samples=4000, random_seed=42)
     )
     assert fit_res.mini is not None
     assert hasattr(fit_res.mini, "posterior")
     trace = fit_res.mini
 
     # 3. Analyze Results
-    summary = az.summary(trace)
+    # Keep full float precision: ``az.summary`` rounds to 2 decimals by default,
+    # which collapses the small shift onto the 7.0 boundary.
+    summary = az.summary(trace, round_to=8)
     means = {str(key): float(value) for key, value in summary["mean"].to_dict().items()}
 
     # Check x_true posterior for the 3rd point (index 2)

--- a/tests/test_model_validation_smoke.py
+++ b/tests/test_model_validation_smoke.py
@@ -940,3 +940,21 @@ def test_residual_diagnostics_plot_col_requires_annotation() -> None:
     })
     with pytest.raises(ValueError, match="annotate"):
         ResidualDiagnostics(df).plot_col()
+
+
+def test_residual_diagnostics_analysis_methods_smoke() -> None:
+    """ResidualDiagnostics exposes the distribution/trend/correlation analyses."""
+    df = pd.DataFrame({
+        "trace_id": ["m1"] * 8,
+        "well": ["A01", "A02"] * 4,
+        "label": ["1", "1", "2", "2"] * 2,
+        "step": [0, 0, 0, 0, 1, 1, 1, 1],
+        "x": [8.9, 8.9, 8.9, 8.9, 8.2, 8.2, 8.2, 8.2],
+        "std_res": np.linspace(-1.0, 1.0, 8),
+    })
+    diag = ResidualDiagnostics(df)
+    assert len(diag.distribution_summary()) == 2  # one row per label
+    assert isinstance(diag.x_correlation(), pd.DataFrame)
+    lag, lag_summary = diag.lag1_autocorrelation()
+    assert isinstance(lag, pd.DataFrame)
+    assert isinstance(lag_summary, pd.DataFrame)

--- a/tests/test_outlier_scores.py
+++ b/tests/test_outlier_scores.py
@@ -130,7 +130,7 @@ def test_fit_gain_recovers_known_gain() -> None:
     floor, true_gain = 5.0, 0.8
     sigma = np.sqrt(floor**2 + true_gain * y_pred)
     resid = sigma * rng.standard_normal(400)
-    df = pd.DataFrame({"label": "1", "resid_raw": resid, "predicted": y_pred})
+    df = pd.DataFrame({"label": "1", "raw_res": resid, "that": y_pred})
     gain = fit_gain_from_residuals(df, sigma_floor={"1": floor})
     assert abs(gain["1"] - true_gain) / true_gain < 0.2
 
@@ -143,7 +143,7 @@ def test_fit_gain_multi_label() -> None:
     for lbl, gain_true, floor in [("1", 1.0, 5.0), ("2", 2.0, 3.0)]:
         sigma = np.sqrt(floor**2 + gain_true * y)
         resid = sigma * rng.standard_normal(200)
-        parts.append(pd.DataFrame({"label": lbl, "resid_raw": resid, "predicted": y}))
+        parts.append(pd.DataFrame({"label": lbl, "raw_res": resid, "that": y}))
     df = pd.concat(parts, ignore_index=True)
     gain = fit_gain_from_residuals(df, sigma_floor={"1": 5.0, "2": 3.0})
     assert gain["1"] >= 0.0
@@ -155,7 +155,7 @@ def test_fit_gain_non_negative_clamped() -> None:
     rng = np.random.default_rng(5)
     y = np.ones(50) * 100
     resid = rng.standard_normal(50) * 0.001
-    df = pd.DataFrame({"label": "1", "resid_raw": resid, "predicted": y})
+    df = pd.DataFrame({"label": "1", "raw_res": resid, "that": y})
     gain = fit_gain_from_residuals(df, sigma_floor={"1": 100.0})
     assert gain["1"] >= 0.0
 
@@ -170,7 +170,7 @@ def test_fit_rel_error_recovers_known_alpha() -> None:
     floor, true_alpha = 5.0, 0.02
     sigma = np.sqrt(floor**2 + (true_alpha * y_pred) ** 2)
     resid = sigma * rng.standard_normal(400)
-    df = pd.DataFrame({"label": "1", "resid_raw": resid, "predicted": y_pred})
+    df = pd.DataFrame({"label": "1", "raw_res": resid, "that": y_pred})
     alpha = fit_rel_error_from_residuals(df, sigma_floor={"1": floor})
     assert abs(alpha["1"] - true_alpha) / true_alpha < 0.2
 
@@ -183,7 +183,7 @@ def test_fit_rel_error_multi_label() -> None:
     for lbl, alpha_true, floor in [("1", 0.02, 5.0), ("2", 0.04, 3.0)]:
         sigma = np.sqrt(floor**2 + (alpha_true * y) ** 2)
         resid = sigma * rng.standard_normal(200)
-        parts.append(pd.DataFrame({"label": lbl, "resid_raw": resid, "predicted": y}))
+        parts.append(pd.DataFrame({"label": lbl, "raw_res": resid, "that": y}))
     df = pd.concat(parts, ignore_index=True)
     alpha = fit_rel_error_from_residuals(df, sigma_floor={"1": 5.0, "2": 3.0})
     assert "1" in alpha
@@ -197,7 +197,7 @@ def test_fit_rel_error_non_negative_clamped() -> None:
     rng = np.random.default_rng(5)
     y = np.ones(50) * 100
     resid = rng.standard_normal(50) * 0.001
-    df = pd.DataFrame({"label": "1", "resid_raw": resid, "predicted": y})
+    df = pd.DataFrame({"label": "1", "raw_res": resid, "that": y})
     alpha = fit_rel_error_from_residuals(df, sigma_floor={"1": 100.0})
     assert alpha["1"] >= 0.0
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,256 @@
+"""Tests for plate-level fitting pipeline orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from clophfit.fitting import pipeline
+from clophfit.fitting.data_structures import DataArray, Dataset, FitResult
+from clophfit.fitting.errors import InsufficientDataError
+
+
+def _dataset() -> Dataset:
+    x = np.array([6.0, 7.0, 8.0])
+    y = np.array([1.0, 2.0, 3.0])
+    return Dataset({"1": DataArray(x, y, y_errc=np.ones_like(y))}, is_ph=True)
+
+
+@dataclass
+class _Result:
+    residual: np.ndarray
+    success: bool = True
+
+
+def test_noise_model_building_and_convergence() -> None:
+    """Noise-model helpers should compare gain and alpha per label."""
+    old = pipeline._plate_noise_model_from_nnls(  # noqa: SLF001
+        {"1": 1.0}, {"1": 0.2}, {"1": 0.03}
+    )
+    same = pipeline._plate_noise_model_from_nnls(  # noqa: SLF001
+        {"1": 1.0}, {"1": 0.2001}, {"1": 0.03001}
+    )
+    changed = pipeline._plate_noise_model_from_nnls(  # noqa: SLF001
+        {"1": 1.0}, {"1": 0.3}, {"1": 0.03}
+    )
+    missing = pipeline._plate_noise_model_from_nnls(  # noqa: SLF001
+        {"1": 1.0, "2": 2.0},
+        {"1": 0.2, "2": 0.0},
+        {"1": 0.03, "2": 0.0},
+    )
+
+    assert old["1"].sigma_floor == 1.0
+    assert old["1"].sigma_ph == 0.0
+    assert pipeline._noise_params_converged(old, same, tol=1e-2)  # noqa: SLF001
+    assert not pipeline._noise_params_converged(  # noqa: SLF001
+        old, changed, tol=1e-2
+    )
+    assert not pipeline._noise_params_converged(  # noqa: SLF001
+        old, missing, tol=1e-2
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "target"),
+    [
+        ("", "lm"),
+        ("huber", "huber"),
+        ("odr", "odr"),
+        ("mcmc", "mcmc"),
+    ],
+)
+def test_fit_plate_routes_methods_and_preserves_well_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+    target: str,
+) -> None:
+    """Plate fitting should dispatch each method to the intended backend."""
+    calls: list[tuple[str, str]] = []
+
+    def fake_glob(
+        ds: Dataset, *, method: str = "lm", **_kwargs: object
+    ) -> FitResult[Any]:
+        calls.append(("glob", method))
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    def fake_odr(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+        calls.append(("odr", "odr"))
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    def fake_mcmc(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+        calls.append(("mcmc", "mcmc"))
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_glob", fake_glob)
+    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_odr", fake_odr)
+    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_pymc", fake_mcmc)
+
+    results = pipeline.fit_plate({"A01": _dataset(), "A02": _dataset()}, method=method)
+
+    assert set(results) == {"A01", "A02"}
+    assert all(fr.result is not None for fr in results.values())
+    assert calls == [(target if target in {"odr", "mcmc"} else "glob", target)] * 2
+
+
+@pytest.mark.parametrize("method", ["lm", "odr", "mcmc"])
+def test_fit_plate_turns_insufficient_data_into_empty_result(
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+) -> None:
+    """Per-well insufficient-data failures should not abort the whole plate."""
+
+    def fail(*_args: object, **_kwargs: object) -> FitResult[Any]:
+        msg = "too few points"
+        raise InsufficientDataError(msg)
+
+    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_glob", fail)
+    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_odr", fail)
+    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_pymc", fail)
+
+    results = pipeline.fit_plate({"A01": _dataset()}, method=method)
+
+    assert results["A01"].result is None
+
+
+def test_fgls_plate_fit_uses_calibration_fallback_and_second_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FGLS should continue with fixed floors when calibration raises."""
+    methods: list[str] = []
+
+    def fake_fit(
+        ds: Dataset, *, method: str = "lm", **_kwargs: object
+    ) -> FitResult[Any]:
+        methods.append(method)
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    def fake_residuals(results: dict[str, FitResult[Any]]) -> pd.DataFrame:
+        assert "A01" in results
+        return pd.DataFrame({
+            "well": ["A01"],
+            "label": ["1"],
+            "x": [7.0],
+            "resid_weighted": [0.0],
+            "resid_raw": [0.0],
+            "y_err": [1.0],
+            "predicted": [2.0],
+        })
+
+    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_glob", fake_fit)
+    monkeypatch.setattr(
+        "clophfit.fitting.pipeline.collect_multi_residuals", fake_residuals
+    )
+    monkeypatch.setattr(
+        "clophfit.fitting.pipeline.fit_noise_model_nnls",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("singular")),
+    )
+    monkeypatch.setattr(
+        "clophfit.fitting.pipeline.compute_plate_slopes", lambda *_args: {}
+    )
+    monkeypatch.setattr(
+        "clophfit.fitting.pipeline.fit_ph_slope_noise", lambda *_args: 0.05
+    )
+
+    first_method = "huber"
+    second_method = "lm"
+    results, noise = pipeline.fgls_plate_fit(
+        {"A01": _dataset()},
+        {"1": 1.0},
+        first_pass_method=first_method,
+        second_pass_method=second_method,
+        max_iter=2,
+    )
+
+    assert methods == ["huber", "lm"]
+    assert results["A01"].result is not None
+    assert noise["1"].sigma_floor == 1.0
+    assert noise["1"].gain == 0.0
+    assert noise["1"].alpha == 0.0
+    assert noise["1"].sigma_ph == 0.05
+
+
+def test_fgls_plate_fit_converges_and_handles_failed_well(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FGLS should insert empty FitResult for failed wells."""
+    calls = 0
+
+    def fake_fit(
+        ds: Dataset, *, method: str = "lm", **_kwargs: object
+    ) -> FitResult[Any]:
+        nonlocal calls
+        assert method in {"huber", "lm"}
+        calls += 1
+        if ds is datasets["bad"]:
+            msg = "too few points"
+            raise InsufficientDataError(msg)
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    def fake_residuals(_results: dict[str, FitResult[Any]]) -> pd.DataFrame:
+        return pd.DataFrame({
+            "well": ["good"],
+            "label": ["1"],
+            "x": [7.0],
+            "resid_weighted": [0.0],
+            "resid_raw": [0.0],
+            "y_err": [1.0],
+            "predicted": [2.0],
+        })
+
+    datasets = {"good": _dataset(), "bad": _dataset()}
+    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_glob", fake_fit)
+    monkeypatch.setattr(
+        "clophfit.fitting.pipeline.collect_multi_residuals", fake_residuals
+    )
+    monkeypatch.setattr(
+        "clophfit.fitting.pipeline.fit_noise_model_nnls",
+        lambda *_args, **_kwargs: ({"1": 1.0}, {"1": 0.2}, {"1": 0.03}),
+    )
+    monkeypatch.setattr(
+        "clophfit.fitting.pipeline.compute_plate_slopes", lambda *_args: {}
+    )
+    monkeypatch.setattr(
+        "clophfit.fitting.pipeline.fit_ph_slope_noise", lambda *_args: 0.0
+    )
+
+    results, noise = pipeline.fgls_plate_fit(datasets, {"1": 1.0}, max_iter=1, tol=1e-9)
+
+    assert calls == 2
+    assert results["good"].result is not None
+    assert results["bad"].result is None
+    assert noise["1"].gain == 0.2
+
+
+def test_calibrate_noise_robust_screens_high_p_outlier() -> None:
+    """A high-p_outlier point is dropped, so it no longer inflates the gain."""
+    y = np.linspace(50.0, 500.0, 120)
+    df = pd.DataFrame({
+        "label": "1",
+        "raw_res": np.full(120, 2.0),
+        "that": y,
+        "p_outlier_per_point": np.zeros(120),
+    })
+    # Inject one gross outlier flagged by the mixture.
+    df.loc[0, "raw_res"] = 1.0e4
+    df.loc[0, "p_outlier_per_point"] = 0.99
+
+    screened = pipeline.calibrate_noise_robust(df, {"1": 1.0}, p_threshold=0.9)
+    # p_threshold above 1.0 keeps every point (nothing screened).
+    unscreened = pipeline.calibrate_noise_robust(df, {"1": 1.0}, p_threshold=2.0)
+
+    assert screened["1"].sigma_floor == 1.0
+    assert screened["1"].gain < unscreened["1"].gain
+
+
+def test_calibrate_noise_robust_without_probability_column() -> None:
+    """Without p_outlier_per_point, all points are used (no screening)."""
+    y = np.linspace(50.0, 500.0, 80)
+    df = pd.DataFrame({"label": "1", "raw_res": np.full(80, 2.0), "that": y})
+    model = pipeline.calibrate_noise_robust(df, {"1": 1.5})
+    assert model["1"].sigma_floor == 1.5
+    assert model["1"].gain >= 0.0
+    assert model["1"].alpha >= 0.0

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 from lmfit.minimizer import MinimizerResult  # type: ignore[import-untyped]
 
 from clophfit.fitting.core import fit_binding_glob
@@ -13,6 +14,7 @@ from clophfit.fitting.data_structures import (
     NoiseModelParams,
     PlateNoiseModel,
 )
+from clophfit.fitting.model_validation import robust_settings_from_trace
 from clophfit.fitting.models import binding_1site
 from clophfit.fitting.pipeline import fgls_plate_fit
 from clophfit.fitting.residuals import (
@@ -100,30 +102,34 @@ class TestResidualPoint:
         point = ResidualPoint(
             label="1",
             x=7.0,
-            resid_weighted=0.5,
-            resid_raw=5.0,
+            y=1000.0,
+            that=995.0,
+            sigma=10.0,
+            raw_res=5.0,
+            likelihood_res=0.5,
+            std_res=0.5,
             raw_i=0,
-            y_err=10.0,
-            predicted=995.0,
         )
         assert point.label == "1"
         assert point.x == 7.0
-        assert point.resid_weighted == 0.5
-        assert point.resid_raw == 5.0
+        assert point.std_res == 0.5
+        assert point.raw_res == 5.0
         assert point.raw_i == 0
-        assert point.y_err == 10.0
-        assert point.predicted == 995.0
+        assert point.sigma == 10.0
+        assert point.that == 995.0
 
     def test_frozen(self) -> None:
         """Test that ResidualPoint is immutable."""
         point = ResidualPoint(
             label="1",
             x=7.0,
-            resid_weighted=0.5,
-            resid_raw=5.0,
+            y=1000.0,
+            that=995.0,
+            sigma=10.0,
+            raw_res=5.0,
+            likelihood_res=0.5,
+            std_res=0.5,
             raw_i=0,
-            y_err=10.0,
-            predicted=995.0,
         )
         with pytest.raises(AttributeError):
             point.x = 8.0  # type: ignore[misc]
@@ -142,8 +148,8 @@ class TestExtractResidualPoints:
         points = extract_residual_points(simple_fit_result)
         assert len(points) == 5
         assert all(p.label == "1" for p in points)
-        assert all(isinstance(p.resid_weighted, float) for p in points)
-        assert all(isinstance(p.resid_raw, float) for p in points)
+        assert all(isinstance(p.std_res, float) for p in points)
+        assert all(isinstance(p.raw_res, float) for p in points)
 
     def test_multi_label(
         self, multi_label_fit_result: FitResult[MinimizerResult]
@@ -193,8 +199,8 @@ class TestExtractResidualPoints:
         points = extract_residual_points(fr)
 
         assert [p.raw_i for p in points] == [0, 2, 3, 4]
-        assert [p.resid_weighted for p in points] == [1.0, 3.0, 4.0, 5.0]
-        assert 99.0 not in [p.resid_weighted for p in points]
+        assert [p.std_res for p in points] == [1.0, 3.0, 4.0, 5.0]
+        assert 99.0 not in [p.std_res for p in points]
 
 
 ###############################################################################
@@ -211,11 +217,13 @@ class TestResidualDataframe:
         expected_cols = {
             "label",
             "x",
-            "resid_weighted",
-            "resid_raw",
+            "y",
+            "that",
+            "sigma",
+            "raw_res",
+            "likelihood_res",
+            "std_res",
             "raw_i",
-            "y_err",
-            "predicted",
         }
         assert set(df.columns) == expected_cols
 
@@ -229,13 +237,52 @@ class TestResidualDataframe:
         df = residual_dataframe(empty_fit_result)
         assert len(df) == 0
 
+
+class TestResidualsEntryPoint:
+    """The FitResult.residuals cached-property entry point."""
+
+    def test_fitresult_residuals_canonical_and_cached(
+        self, simple_fit_result: FitResult[MinimizerResult]
+    ) -> None:
+        """fr.residuals returns the canonical schema and is cached."""
+        r = simple_fit_result.residuals
+        assert {"raw_res", "that", "std_res", "sigma", "raw_i", "label", "x"} <= set(
+            r.columns
+        )
+        assert simple_fit_result.residuals is r  # cached (same object)
+
+    def test_residual_table_override(
+        self, simple_fit_result: FitResult[MinimizerResult]
+    ) -> None:
+        """residual_table(...) yields the same columns as the property."""
+        table = simple_fit_result.residual_table(robust=False)
+        assert list(table.columns) == list(simple_fit_result.residuals.columns)
+
+    def test_robust_settings_from_trace(self) -> None:
+        """Robustness is inferred from posterior variable names."""
+        assert robust_settings_from_trace(None) == (False, 3.0)
+        post = xr.Dataset(
+            {"student_t_nu": (("chain", "draw"), np.array([[4.0, 6.0]]))},
+            coords={"chain": [0], "draw": [0, 1]},
+        )
+        trace = xr.DataTree.from_dict({"posterior": post})
+        robust, nu = robust_settings_from_trace(trace)
+        assert robust is True
+        assert nu == 5.0
+        mix = xr.Dataset(
+            {"pi_outlier_1": (("chain", "draw"), np.array([[0.1, 0.2]]))},
+            coords={"chain": [0], "draw": [0, 1]},
+        )
+        mtrace = xr.DataTree.from_dict({"posterior": mix})
+        assert robust_settings_from_trace(mtrace)[0] is True
+
     def test_dtypes(self, simple_fit_result: FitResult[MinimizerResult]) -> None:
         """Test DataFrame column dtypes."""
         df = residual_dataframe(simple_fit_result)
         assert pd.api.types.is_string_dtype(df["label"])
         assert df["x"].dtype == np.float64
-        assert df["resid_weighted"].dtype == np.float64
-        assert df["resid_raw"].dtype == np.float64
+        assert df["std_res"].dtype == np.float64
+        assert df["raw_res"].dtype == np.float64
         assert df["raw_i"].dtype == np.int64
 
 
@@ -322,9 +369,9 @@ class TestResidualStatistics:
         # Create DataFrame with known outliers
         data = {
             "label": ["1"] * 10,
-            "resid_weighted": [0.0, 0.1, -0.1, 0.2, -0.2, 3.0, -3.0, 0.0, 0.1, -0.1],
+            "std_res": [0.0, 0.1, -0.1, 0.2, -0.2, 3.0, -3.0, 0.0, 0.1, -0.1],
             "x": list(range(10)),
-            "resid_raw": [0.0] * 10,
+            "raw_res": [0.0] * 10,
             "i": list(range(10)),
         }
         df = pd.DataFrame(data)
@@ -336,9 +383,9 @@ class TestResidualStatistics:
         """Test outlier rate calculation."""
         data = {
             "label": ["1"] * 10,
-            "resid_weighted": [0.0] * 8 + [3.0, -3.0],  # 2 outliers out of 10
+            "std_res": [0.0] * 8 + [3.0, -3.0],  # 2 outliers out of 10
             "x": list(range(10)),
-            "resid_raw": [0.0] * 10,
+            "raw_res": [0.0] * 10,
             "i": list(range(10)),
         }
         df = pd.DataFrame(data)
@@ -355,7 +402,7 @@ class TestResidualDiagnosticsHelpers:
             "well": ["A01", "A01", "A01", "A01", "A02", "A02", "A02", "A02"] * 2,
             "label": ["1"] * 8 + ["2"] * 8,
             "x": [6.0, 7.0, 8.0, 9.0, 6.0, 7.0, 8.0, 9.0] * 2,
-            "resid_weighted": [
+            "std_res": [
                 -1.0,
                 0.0,
                 1.0,
@@ -398,7 +445,7 @@ class TestResidualDiagnosticsHelpers:
             "well": ["A01", "A01", "A01"],
             "label": ["1", "1", "1"],
             "x": [6.0, 7.0, 8.0],
-            "resid_weighted": [1.0, 1.0, 1.0],
+            "std_res": [1.0, 1.0, 1.0],
         })
 
         rows, by_label = detect_adjacent_correlation(df)


### PR DESCRIPTION
Stacked on #1384. Tames the ~40-function residual sprawl by fixing its root
cause: two incompatible residual-table schemas and no single way to get
residuals from a fit.

## One schema (canonical = the PyMC `RESIDUAL_TABLE_COLUMNS`)
- lmfit/ODR producers (`ResidualPoint`, `residual_dataframe`,
  `collect_multi_residuals`) now emit `raw_res`/`that`/`sigma`/`std_res`/`raw_i`
  (was `resid_raw`/`predicted`/`y_err`/`resid_weighted`); PyMC producers gained
  `raw_i`. Noise estimators and analysis/plot helpers read the canonical names.

## One entry point
- `FitResult.residuals` / `MultiFitResult.residuals` — lazy `cached_property`
  returning the canonical table for either backend (+ `residual_table(...)`
  override). Robustness auto-detected from the trace
  (`robust_settings_from_trace`); lazy import breaks the
  `data_structures ↔ model_validation` cycle.

## Also
- `pipeline.calibrate_noise_robust`: mixture-`p_outlier` screen → single-term
  gain/alpha calibration (outlier- and collinearity-robust), consuming
  `multi.residuals` directly.
- `ResidualDiagnostics` gains `distribution_summary`/`x_correlation`/
  `lag1_autocorrelation` and a docstring index, becoming the single fluent
  analysis home.

`arslanbaeva` scripts migrated separately (that repo). Full suite green (one
pre-existing flaky MCMC test, passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)