### PR TITLE
docs: consolidate prtecan QC + residual showcases into tutorial

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -778,3 +778,48 @@ Old prior for L2 V224L CTR (mean=5.54, σ=0.20) was 3.8σ from MCMC posterior
 ** Next steps
 - Re-run with C05 excluded or investigate C05 data quality (potential overflow)
 - Consider switching sampler (blackjax/numpyro) to avoid pytensor graph limit
+
+* TODO Revisit x-error step-sigma prior in create_x_true (looks wrong)
+** Problem
+=create_x_true= (src/clophfit/fitting/bayes.py:~882-892) does NOT give each pH
+point an independent x-error prior. It builds x_true as a cumulative sum
+(x_true = x_start + cumsum(x_step)) and derives each step sigma from the
+*running maximum* of x_errc:
+  cummax        = np.maximum.accumulate(x_errc * n_xerr)
+  σ(x_start)    = cummax[0]
+  σ(x_step[k])  = sqrt(cummax[k+1]² - cummax[k]²)   # floored at 1e-6
+A step only gets freedom when its point sets a NEW max in x_errc. Any point
+whose error is <= the running max collapses to σ≈1e-6 and is effectively
+pinned. This is order-dependent and physically odd: a point with a real,
+nonzero pH error can end up with zero independent step freedom just because an
+earlier point happened to have an equal/larger error.
+
+** Evidence (tutorial, well D10, tests/Tecan/L1)
+  xc     = [8.9,  8.3,  7.7,  7.05, 6.55, 6.0,  5.5 ]
+  x_errc = [0.04, 0.05, 0.05, 0.06, 0.07, 0.08, 0.10]
+x_errc[2]==x_errc[1]=0.05 (not a new max) => x_step[1] prior σ = √(0.05²-0.05²)
+=> 1e-6. az.summary then reports x_step[1] mean=0.6, sd=9.8e-7, hdi 0.6..0.6
+(virtually certain), while r_hat=1.0 and ess~3.7k are healthy — so it's the
+prior, not sampling. Reproduced: prior step sigmas match the posterior sds
+almost exactly (data barely updates the x-steps).
+
+** Nuance (why it "mostly works" today)
+The variances telescope so the MARGINAL uncertainty is still sane:
+  Var(x_true[i]) = σ(x_start)² + Σ σ(x_step[k])² = cummax[i]²
+i.e. x_true[i] marginal sd = running-max(x_errc[0..i]). So x_true is fine to
+read; only the per-step reparameterization looks pinned. But the running-max
+(rather than per-point) coupling is the suspicious bit and probably not what we
+want.
+
+** To decide / do
+- Should each point's step reflect its OWN x_errc (independent TruncatedNormal
+  per gap), decoupled from earlier points? That removes the pinning but must
+  still keep x_true ordered (monotone pH) — the original reason for the
+  cumulative/monotone construction.
+- If keeping monotonicity, reconsider whether running-max accumulation is the
+  right way to allocate per-step variance (vs. e.g. per-point σ with an
+  ordering constraint / soft penalty).
+- Add a regression test asserting a point with x_errc <= a neighbor's still
+  gets nonzero step freedom (once the intended behavior is decided).
+- Meanwhile, note in docs/tutorials/prtecan.ipynb that a near-zero x_step row
+  is expected under the current prior so readers aren't alarmed.

--- a/docs/tutorials/prtecan.ipynb
+++ b/docs/tutorials/prtecan.ipynb
@@ -419,6 +419,110 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Quality control: flagging bad wells\n",
+    "\n",
+    "Titrations often contain flat or dead wells (pipetting errors, missing\n",
+    "fluorophore). `plot_qc_span_vs_center_titration` plots each well's dynamic\n",
+    "range (inter-quantile *span*) against a robust signal amplitude (the `q90`\n",
+    "quantile), fits a robust Theil–Sen trend over the **sample** wells, and flags\n",
+    "wells below that trend or a background floor. Buffer wells are excluded;\n",
+    "control wells are shown for reference (named when they sit off the trend) but\n",
+    "never flagged by the trend criterion — only by the background floor.\n",
+    "\n",
+    "`qc_flag_bad_wells_titration` returns the flagged wells **without** mutating\n",
+    "the titration; `Titration.detect_and_discard_bad_wells` applies the discard\n",
+    "in place.\n",
+    "\n",
+    "> This example L1 plate is mostly background/buffer wells, so most wells are\n",
+    "> legitimately flagged — that is why the fitting cells above pick specific\n",
+    "> wells such as `D10`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from clophfit.fitting import plotting\n",
+    "\n",
+    "# Non-mutating QC: flagged wells per label, or one combined set across labels.\n",
+    "bad = plotting.qc_flag_bad_wells_titration(\n",
+    "    tit, z_threshold=8, bg_multiplier=2, combine=\"intersection\"\n",
+    ")\n",
+    "print(f\"QC flags {len(bad)} wells (bad in every label)\")\n",
+    "plotting.plot_qc_span_vs_center_titration(tit, z_threshold=8, bg_multiplier=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "\n",
+    "# detect_and_discard_bad_wells mutates the titration (updates scheme.discard\n",
+    "# and clears cached results); preview on a copy to keep the tutorial intact.\n",
+    "preview = copy.deepcopy(tit)\n",
+    "discarded = preview.detect_and_discard_bad_wells()\n",
+    "print(\n",
+    "    f\"detect_and_discard would drop {len(discarded)} wells, \"\n",
+    "    f\"e.g. {sorted(discarded)[:8]}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Residual diagnostics\n",
+    "\n",
+    "Every fit — LMFit, ODR, or PyMC — exposes a **canonical** residual table via\n",
+    "`fr.residuals` (columns `label, x, y, yhat, sigma, raw_res, std_res, …`).\n",
+    "`ResidualDiagnostics` packages the common residual audits, with structural\n",
+    "analyses (per-label bias, covariance, correlation) grouped under `.analysis`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fr = tr_glob[\"D10\"]\n",
+    "# One schema regardless of the fitter that produced it:\n",
+    "fr.residuals[[\"label\", \"x\", \"y\", \"yhat\", \"sigma\", \"std_res\"]].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from clophfit.fitting.model_validation import ResidualDiagnostics\n",
+    "from clophfit.fitting.residuals import collect_multi_residuals\n",
+    "\n",
+    "all_res = collect_multi_residuals({w: tr_glob[w] for w in tit.fit_keys})\n",
+    "diag = ResidualDiagnostics(all_res)\n",
+    "diag.normality()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Structural analyses live under `.analysis` (here: systematic bias per label).\n",
+    "diag.analysis.label_bias()[1]"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/docs/tutorials/prtecan.ipynb
+++ b/docs/tutorials/prtecan.ipynb
@@ -331,7 +331,9 @@
     "ds_mcmc = {\"D10\": tit.create_global_ds(\"D10\")}\n",
     "res_mcmc = fit_plate(ds_mcmc, method=\"mcmc\")\n",
     "tr_mcmc = TitrationResults(tit.scheme, tit.fit_keys, res_mcmc)\n",
-    "tr_mcmc"
+    "\n",
+    "fr_mcmc = tr_mcmc[well]\n",
+    "fr_mcmc.mini"
    ]
   },
   {
@@ -349,8 +351,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rp = tr_mcmc[well]\n",
-    "rp.figure"
+    "fr_mcmc.figure"
    ]
   },
   {
@@ -359,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "az.plot_trace_dist(rp.mini, var_names=[\"x_true\", \"K\", \"x_diff\"])"
+    "az.plot_trace_dist(fr_mcmc.mini, var_names=[\"x_true\", \"K\", \"x_step\"])"
    ]
   },
   {
@@ -376,16 +377,6 @@
     "print(\n",
     "    f\"95% HDI: [{result_mcmc.result.params['K'].min:.2f}, {result_mcmc.result.params['K'].max:.2f}]\"\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Plot trace\n",
-    "az.plot_trace_dist(result_mcmc.mini, var_names=[\"K\", \"x_true\"]);"
    ]
   },
   {
@@ -451,10 +442,10 @@
     "\n",
     "# Non-mutating QC: flagged wells per label, or one combined set across labels.\n",
     "bad = plotting.qc_flag_bad_wells_titration(\n",
-    "    tit, z_threshold=8, bg_multiplier=2, combine=\"intersection\"\n",
+    "    tit, z_threshold=8, bg_multiplier=0.5, combine=\"intersection\"\n",
     ")\n",
     "print(f\"QC flags {len(bad)} wells (bad in every label)\")\n",
-    "plotting.plot_qc_span_vs_center_titration(tit, z_threshold=8, bg_multiplier=2)"
+    "g = plotting.plot_qc_span_vs_center_titration(tit, z_threshold=4, bg_multiplier=0.3)"
    ]
   },
   {

--- a/prtecan_devel.ipynb
+++ b/prtecan_devel.ipynb
@@ -6,11 +6,20 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "### Tips for development vs tutorial hygiene:\n",
+    "### Scratchpad — `prtecan_devel.ipynb`\n",
     "---\n",
-    "- Keep a scratch notebook (e.g., `prtecan_devel.ipynb`) for experiments.\n",
-    "- Avoid `os.chdir`; use Path objects relative to repository root as in this notebook.\n",
-    "- When a feature stabilizes, port minimal, clear examples into the main tutorial and keep heavy testing in `tests/`."
+    "This is a **development scratchpad** for experiments and new-feature\n",
+    "prototyping. Stabilized, consolidated showcases live in the tutorial:\n",
+    "**`docs/tutorials/prtecan.ipynb`**.\n",
+    "\n",
+    "Already ported to the tutorial:\n",
+    "- Quality control: bad-well detection (`plot_qc_span_vs_center_titration`,\n",
+    "  `qc_flag_bad_wells_titration`, `Titration.detect_and_discard_bad_wells`).\n",
+    "- Residual diagnostics (`fr.residuals`, `ResidualDiagnostics`, `.analysis`).\n",
+    "\n",
+    "Conventions: keep experiments here; port minimal, clear examples to the\n",
+    "tutorial when a feature stabilizes; keep heavy testing in `tests/`. Avoid\n",
+    "`os.chdir`; use `Path` objects relative to the repository root."
    ]
   },
   {
@@ -1421,13 +1430,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "nm_d = {lbl: NoiseModelParams(tit.bg_noise[lbl], sigma_ph=0.02) for lbl in tit.data}\n",
     "nm_d = {lbl: NoiseModelParams(1, 0, 0) for lbl in tit.data}\n",
@@ -1445,13 +1447,6 @@
     "ds = utils.apply_outlier_mask(ds)\n",
     "ds"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -2537,13 +2532,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "  initial_ye = []\n",
     "  for well, refit in refits_glob_a.items():\n",
@@ -2593,13 +2581,6 @@
     "  sns.relplot(data=initial_ye_vs_res, x=\"ye_mean\", y=\"raw_sd\", col=\"label\", hue=\"role\")\n",
     "  sns.relplot(data=initial_ye_vs_res, x=\"ye_mean\", y=\"rel_sd\", col=\"label\", hue=\"role\")\n",
     "  sns.relplot(data=initial_ye_vs_res, x=\"ye_mean\", y=\"sigma_med\", col=\"label\", hue=\"role\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## ... continue"
    ]
   },
   {
@@ -2713,13 +2694,6 @@
    "source": [
     "fr.result.residual"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -3092,13 +3066,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "utils.outlier_scores_extended(ds[\"1\"].x[:], ds[\"1\"].y)"
    ]
@@ -3131,13 +3098,6 @@
     "residue_df = residuals.residual_dataframe(fr)\n",
     "residue_df"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -3385,13 +3345,6 @@
    "source": [
     "fr.dataset[\"1\"]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -4034,13 +3987,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "ds, thruth = make_dataset(\n",
     "    7.0, 2000, 200, is_ph=True, n_labels=1, error_model=\"realistic\"\n",
@@ -4062,13 +4008,6 @@
     "    fr.result.residual * fr.dataset[\"0\"].y_err / fr.dataset[\"0\"].y,\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -5253,13 +5192,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## eiolo"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -5474,13 +5406,6 @@
     "res = pd.read_parquet(\"/home/dati/arslanbaeva/data/interim/fit_grid/residuals/residuals_\" + name + \".parquet\")\n",
     "res[res[\"label\"]==\"2\"][np.abs(res[\"std_res\"])>3]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/src/clophfit/fitting/plotting.py
+++ b/src/clophfit/fitting/plotting.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import re
 import warnings
 from dataclasses import InitVar, dataclass, field
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, overload
 
 import arviz as az  # type: ignore[import-untyped]
 import corner  # type: ignore[import-untyped]
@@ -1548,6 +1548,30 @@ def plot_qc_span_vs_center(  # noqa: PLR0913, PLR0917
     return fig
 
 
+@overload
+def qc_flag_bad_wells(
+    data: Mapping[str, Mapping[str, ArrayF]],
+    *,
+    center: str | float = ...,
+    span_q: tuple[float, float] | None = ...,
+    z_threshold: float = ...,
+    bg_noise: Mapping[str, float | ArrayF] | Mapping[int, float | ArrayF] | None = ...,
+    bg_multiplier: float = ...,
+    ctrl_wells: Iterable[str] = ...,
+    combine: None = ...,
+) -> dict[str, list[str]]: ...
+@overload
+def qc_flag_bad_wells(
+    data: Mapping[str, Mapping[str, ArrayF]],
+    *,
+    center: str | float = ...,
+    span_q: tuple[float, float] | None = ...,
+    z_threshold: float = ...,
+    bg_noise: Mapping[str, float | ArrayF] | Mapping[int, float | ArrayF] | None = ...,
+    bg_multiplier: float = ...,
+    ctrl_wells: Iterable[str] = ...,
+    combine: Literal["intersection", "union"],
+) -> list[str]: ...
 def qc_flag_bad_wells(  # noqa: PLR0913
     data: Mapping[str, Mapping[str, ArrayF]],
     *,
@@ -1648,6 +1672,26 @@ def _titration_ctrl_wells(tit: object) -> list[str]:
     return list(getattr(getattr(tit, "scheme", None), "ctrl", []) or [])
 
 
+@overload
+def qc_flag_bad_wells_titration(
+    tit: object,
+    *,
+    center: str | float = ...,
+    span_q: tuple[float, float] | None = ...,
+    z_threshold: float = ...,
+    bg_multiplier: float = ...,
+    combine: None = ...,
+) -> dict[str, list[str]]: ...
+@overload
+def qc_flag_bad_wells_titration(
+    tit: object,
+    *,
+    center: str | float = ...,
+    span_q: tuple[float, float] | None = ...,
+    z_threshold: float = ...,
+    bg_multiplier: float = ...,
+    combine: Literal["intersection", "union"],
+) -> list[str]: ...
 def qc_flag_bad_wells_titration(  # noqa: PLR0913
     tit: object,
     *,


### PR DESCRIPTION
## Summary
Completes the split between the **tutorial** (`docs/tutorials/prtecan.ipynb`, curated showcases) and the **scratchpad** (`prtecan_devel.ipynb`, experiments).

### Tutorial — new consolidated showcases
- **Quality control: flagging bad wells** — `plot_qc_span_vs_center_titration` (robust q90 amplitude + inter-quantile span + Theil–Sen trend), the non-mutating `qc_flag_bad_wells_titration` (buffers excluded, controls excluded from the z-score but still subject to the background floor, `combine="intersection"`), and the mutating `Titration.detect_and_discard_bad_wells` previewed on a copy.
- **Residual diagnostics** — the unified `fr.residuals` canonical table (`label, x, y, yhat, sigma, std_res, …`), `ResidualDiagnostics`, and structural analyses under `.analysis`.

All new cells were verified to run against the shipped `tests/Tecan/L1` data.

### Scratchpad — migrated + cleaned
- Migrated to the current API: canonical residual schema (`resid_weighted→std_res`, `resid_raw→raw_res`, `predicted→yhat`), consolidation onto `ResidualAnalysis`.
- Removed 12 empty / dead scratch cells (incl. `## eiolo`, `## ... continue`).
- Header rewritten to mark it a scratchpad and record what was ported.

## Notes
- The underlying library work (ResidualAnalysis, `that→yhat` rename, robust QC detector, dead-flag removal) is already on `main`; this PR is the notebook/docs layer.
- `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)