### PR TITLE
test(fitting): stabilize flaky test_fit_binding_pymc_ph on macOS/py3.12

### DIFF
--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -870,7 +870,15 @@ def test_fit_binding_odr_multi(multi_dataset: Dataset) -> None:
 
 def test_fit_binding_pymc_ph(ph_dataset: Dataset) -> None:
     """Test PyMC Bayesian fitting on pH dataset."""
-    fr = fit_binding_pymc(ph_dataset, n_sd=1.0, sampler=SamplerConfig(n_samples=100))
+    # n_tune must be set explicitly: with n_samples=100 the default (n_samples//2
+    # = 50 warmup draws) under-tunes NUTS, biasing K high (~8, at the assertion
+    # boundary) and making the test platform-flaky. A fixed seed keeps it
+    # reproducible.
+    fr = fit_binding_pymc(
+        ph_dataset,
+        n_sd=1.0,
+        sampler=SamplerConfig(n_samples=200, n_tune=500, random_seed=42),
+    )
     assert fr.result is not None
     assert "K" in fr.result.params
     # Check K value is reasonable


### PR DESCRIPTION
## Problem

`tests/test_fitting.py::test_fit_binding_pymc_ph` fails intermittently on macOS/py3.12 (`AssertionError: assert 8.3 < 8.0`).

## Root cause

The test ran `SamplerConfig(n_samples=100)`, which leaves `n_tune` at its default `n_samples // 2 = 50`. 50 NUTS warmup draws is too few to adapt the step size / mass matrix, so the posterior-mean **K converges biased-high (~8.0)** — right on the `assert 6.0 < K < 8.0` boundary. Linux lands at 6.8–8.0 (passes by a hair); macOS/py3.12 nutpie tips to 8.3 and fails.

Not a regression: the single-well `fit_binding_pymc` path is byte-identical to the merge base (`git diff` shows only multi-well renames). Pre-existing latent flake.

## Fix

```python
sampler=SamplerConfig(n_samples=200, n_tune=500, random_seed=42)
```

Adequate warmup makes K converge to the true **7.0 reproducibly** across platforms, in the same ~1.3s; the seed makes it deterministic. Bound `[6, 8]` kept — K=7.0 now sits centered instead of on the edge. Only this test asserts a tight K *value* bound; the neighboring pymc tests check structure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)