### PR TITLE
refactor(residuals): rename p_outlier_per_point column to p_outlier

### DIFF
--- a/src/clophfit/fitting/data_structures.py
+++ b/src/clophfit/fitting/data_structures.py
@@ -572,7 +572,7 @@ class MultiFitResult:
         """Canonical per-observation residual table across all wells.
 
         Lazily computed, cached, and returned in the shared schema
-        (``RESIDUAL_TABLE_COLUMNS``, including ``p_outlier_per_point`` extracted
+        (``RESIDUAL_TABLE_COLUMNS``, including ``p_outlier`` extracted
         from the trace). Robustness is auto-detected; use :meth:`residual_table`
         to override.
         """

--- a/src/clophfit/fitting/model_validation.py
+++ b/src/clophfit/fitting/model_validation.py
@@ -45,7 +45,7 @@ RESIDUAL_TABLE_COLUMNS = [
     "raw_res",
     "likelihood_res",
     "std_res",
-    "p_outlier_per_point",
+    "p_outlier",
     "residual_likelihood",
     "student_t_nu",
     "is_residual_outlier",
@@ -880,7 +880,7 @@ def masked_datasets_from_residual_outliers(
 def mark_outlier_probability_outliers(
     residuals: _t.Any,
     *,
-    probability_col: str = "p_outlier_per_point",
+    probability_col: str = "p_outlier",
     threshold: float = 0.9,
     exclude_col: str = "exclude_outlier_probability",
 ) -> pd.DataFrame:
@@ -932,7 +932,7 @@ def masked_datasets_from_outlier_probabilities(
     results: _t.Mapping[str, _t.Any],
     residuals: _t.Any,
     *,
-    probability_col: str = "p_outlier_per_point",
+    probability_col: str = "p_outlier",
     threshold: float = 0.9,
     min_keep: int = 3,
 ) -> dict[str, _t.Any]:
@@ -1123,7 +1123,7 @@ def robust_settings_from_trace(trace: _t.Any) -> tuple[bool, float]:
     probability-integral transform", which is correct **only** for a Student-t
     likelihood.  A contamination mixture uses Normal components, so its residuals
     are standardized as Normal (``robust=False``) and its outlier structure is
-    reported through ``p_outlier_per_point`` instead.  Used by
+    reported through ``p_outlier`` instead.  Used by
     ``FitResult.residuals`` / ``MultiFitResult.residuals`` so the residual table
     is standardized correctly without the caller re-supplying fit settings.
 
@@ -1706,7 +1706,7 @@ def residuals_from_multifit(  # noqa: PLR0913
                     "raw_res": float(y[j] - yhat[j]),
                     "likelihood_res": float(likelihood_res[j]),
                     "std_res": float(std_res[j]),
-                    "p_outlier_per_point": float(p_outlier[j]),
+                    "p_outlier": float(p_outlier[j]),
                     "residual_likelihood": family,
                     "student_t_nu": float(student_t_nu) if robust else np.nan,
                     "is_residual_outlier": bool(outlier[j]),
@@ -1762,7 +1762,7 @@ def residuals_from_fit_results(  # noqa: PLR0913
     trace : _t.Any
         Optional PyMC trace. When it carries ``outlier_probability_{label}``
         deterministics (contamination-mixture fits), the per-point posterior
-        outlier probability is extracted into ``p_outlier_per_point``; otherwise
+        outlier probability is extracted into ``p_outlier``; otherwise
         that column is ``NaN``. Mirrors :func:`residuals_from_multifit` so
         single-well and multi-well tables share the full schema.
     residual_likelihood : str | None
@@ -1831,7 +1831,7 @@ def residuals_from_fit_results(  # noqa: PLR0913
                     "raw_res": float(y[j] - yhat[j]),
                     "likelihood_res": float(likelihood_res[j]),
                     "std_res": float(std_res[j]),
-                    "p_outlier_per_point": float(p_outlier[j]),
+                    "p_outlier": float(p_outlier[j]),
                     "residual_likelihood": family,
                     "student_t_nu": float(student_t_nu) if robust else np.nan,
                     "is_residual_outlier": bool(outlier[j]),

--- a/src/clophfit/fitting/pipeline.py
+++ b/src/clophfit/fitting/pipeline.py
@@ -77,7 +77,7 @@ def calibrate_noise_robust(
     label with the single-term moment estimators
     (:func:`~clophfit.fitting.utils.fit_gain_from_residuals`,
     :func:`~clophfit.fitting.utils.fit_rel_error_from_residuals`) on the
-    retained points. Screening with the mixture's ``p_outlier_per_point`` keeps
+    retained points. Screening with the mixture's ``p_outlier`` keeps
     outliers from inflating the estimate, while the two single-term estimators
     avoid the gain/alpha collinearity of the joint NNLS over narrow titration
     ranges.
@@ -87,7 +87,7 @@ def calibrate_noise_robust(
     residuals : pd.DataFrame
         Canonical residual table (e.g. ``MultiFitResult.residuals`` from a
         mixture fit). Must have ``label``, ``raw_res``, ``yhat`` columns; a
-        ``p_outlier_per_point`` column enables screening (otherwise all points
+        ``p_outlier`` column enables screening (otherwise all points
         are used).
     sigma_floor : dict[str, float]
         Known read-noise floor per label, e.g. ``tit.bg_noise``. Used as the
@@ -104,10 +104,10 @@ def calibrate_noise_robust(
         Per-label model with ``sigma_floor`` from *sigma_floor* and calibrated
         ``gain``/``alpha``.
     """
-    if "p_outlier_per_point" in residuals.columns:
+    if "p_outlier" in residuals.columns:
         kept: list[pd.DataFrame] = []
         for _label, group in residuals.groupby("label", observed=True):
-            inliers = group[group["p_outlier_per_point"].fillna(0.0) < p_threshold]
+            inliers = group[group["p_outlier"].fillna(0.0) < p_threshold]
             kept.append(group if len(inliers) < min_keep else inliers)
         clean = pd.concat(kept, ignore_index=True) if kept else residuals
     else:

--- a/tests/test_model_validation_smoke.py
+++ b/tests/test_model_validation_smoke.py
@@ -341,7 +341,7 @@ def test_masked_datasets_from_outlier_probabilities_accepts_ds_dict() -> None:
         "well": ["A01", "A01"],
         "label": ["1", "1"],
         "step": [1, 2],
-        "p_outlier_per_point": [0.9, 0.95],
+        "p_outlier": [0.9, 0.95],
     })
 
     masked = masked_datasets_from_outlier_probabilities({"A01": ds}, residuals)
@@ -715,7 +715,7 @@ def test_residuals_from_multifit_returns_convenient_schema() -> None:
     assert residuals.loc[0, "label"] == "1"
     assert residuals.loc[0, "step"] == 0
     assert residuals.loc[0, "residual_likelihood"] == "normal"
-    assert bool(residuals["p_outlier_per_point"].isna().iloc[0])
+    assert bool(residuals["p_outlier"].isna().iloc[0])
     assert not bool(residuals.loc[0, "is_residual_outlier"])
 
 
@@ -764,7 +764,7 @@ def test_residuals_from_multifit_maps_outlier_probability_by_point() -> None:
         {"well": "A02", "step": 1},
     ]
     np.testing.assert_allclose(
-        residuals["p_outlier_per_point"].to_numpy(),
+        residuals["p_outlier"].to_numpy(),
         np.array([0.1, 0.3, 0.2, 0.4]),
     )
 
@@ -838,8 +838,8 @@ def test_single_well_residuals_extract_p_outlier_from_mixture_trace() -> None:
     )()
     df = _single_well_fit_result(trace).residual_table(robust=False, well="A01")
 
-    assert "p_outlier_per_point" in df.columns
-    assert np.allclose(df["p_outlier_per_point"].to_numpy(), known)
+    assert "p_outlier" in df.columns
+    assert np.allclose(df["p_outlier"].to_numpy(), known)
     # Schema parity with the multi-well builder.
     assert list(df.columns)[: len(RESIDUAL_TABLE_COLUMNS)] == RESIDUAL_TABLE_COLUMNS
 
@@ -858,8 +858,8 @@ def test_single_well_residuals_extract_p_outlier_from_mixture_trace() -> None:
 def test_single_well_residuals_p_outlier_nan_without_mixture(mini: object) -> None:
     """Without a mixture deterministic (or any trace) the column stays NaN."""
     df = _single_well_fit_result(mini).residual_table(robust=False, well="A01")
-    assert "p_outlier_per_point" in df.columns
-    assert df["p_outlier_per_point"].isna().all()
+    assert "p_outlier" in df.columns
+    assert df["p_outlier"].isna().all()
 
 
 def test_single_well_residuals_label_mixture_without_t_transform() -> None:
@@ -867,7 +867,7 @@ def test_single_well_residuals_label_mixture_without_t_transform() -> None:
 
     The mixture uses Normal components, so ``std_res`` must be the identity of
     ``likelihood_res`` (no Student-t transform) and ``student_t_nu`` NaN; the
-    outlier structure is reported via ``p_outlier_per_point``.
+    outlier structure is reported via ``p_outlier``.
     """
     known = np.array([0.02, 0.10, 0.97])
     op = xr.DataArray(np.broadcast_to(known, (2, 4, 3)), dims=["chain", "draw", "obs"])
@@ -892,7 +892,7 @@ def test_single_well_residuals_label_mixture_without_t_transform() -> None:
     np.testing.assert_allclose(
         df["std_res"].to_numpy(), df["likelihood_res"].to_numpy()
     )
-    assert np.allclose(df["p_outlier_per_point"].to_numpy(), known)
+    assert np.allclose(df["p_outlier"].to_numpy(), known)
 
 
 def test_trace_diagnostics_collects_stats_loo_and_x_sanity(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -232,11 +232,11 @@ def test_calibrate_noise_robust_screens_high_p_outlier() -> None:
         "label": "1",
         "raw_res": np.full(120, 2.0),
         "yhat": y,
-        "p_outlier_per_point": np.zeros(120),
+        "p_outlier": np.zeros(120),
     })
     # Inject one gross outlier flagged by the mixture.
     df.loc[0, "raw_res"] = 1.0e4
-    df.loc[0, "p_outlier_per_point"] = 0.99
+    df.loc[0, "p_outlier"] = 0.99
 
     screened = pipeline.calibrate_noise_robust(df, {"1": 1.0}, p_threshold=0.9)
     # p_threshold above 1.0 keeps every point (nothing screened).
@@ -247,7 +247,7 @@ def test_calibrate_noise_robust_screens_high_p_outlier() -> None:
 
 
 def test_calibrate_noise_robust_without_probability_column() -> None:
-    """Without p_outlier_per_point, all points are used (no screening)."""
+    """Without p_outlier, all points are used (no screening)."""
     y = np.linspace(50.0, 500.0, 80)
     df = pd.DataFrame({"label": "1", "raw_res": np.full(80, 2.0), "yhat": y})
     model = pipeline.calibrate_noise_robust(df, {"1": 1.5})

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -278,7 +278,7 @@ class TestResidualsEntryPoint:
         mtrace = xr.DataTree.from_dict({"posterior": mix})
         # A mixture is Normal-standardized (no Student-t transform), so it does
         # not request the robust std_res calibration; its outlier structure is
-        # reported via p_outlier_per_point instead.
+        # reported via p_outlier instead.
         assert robust_settings_from_trace(mtrace) == (False, 3.0)
         assert robust_likelihood_from_trace(mtrace) == "mixture"
         assert robust_likelihood_from_trace(trace) == "student_t"


### PR DESCRIPTION
Renames the mixture per-point posterior outlier-probability column from the long
`p_outlier_per_point` to `p_outlier` in `FitResult.residuals` /
`MultiFitResult.residuals`.

Touches all 25 references: `RESIDUAL_TABLE_COLUMNS`, the `probability_col`
default in `mark_outlier_probability_outliers` / `masked_datasets_from_outlier_probabilities`,
the FGLS noise-calibration screen in `pipeline.py`, and docstrings/tests. No
behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)