### PR TITLE
fix(bayes): scale hierarchical per-well x_step wall to the larger sigma

### DIFF
--- a/src/clophfit/fitting/bayes.py
+++ b/src/clophfit/fitting/bayes.py
@@ -3134,11 +3134,23 @@ def fit_binding_pymc_multi(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
             # Fixed between-well scale — do not sample a variance parameter;
             # the centered funnel destroys sampler performance.
+            #
+            # Bound the per-well deviations 2.5 sigma below the mode, using the
+            # LARGER of the two per-step spreads: the shared-walk ``step_sigmas``
+            # and the between-well ``acid_drop_between_sigma``. The old bound
+            # (``min_drops`` = nominal - 2.5*step_sigmas) uses only step_sigmas,
+            # so when acid_drop_between_sigma is larger the wall sits ~1 sigma
+            # below the per-well mode and clips it; conversely a wall using only
+            # acid_drop_between_sigma would over-truncate the steps whose
+            # step_sigmas is larger. Taking the max keeps a genuine 2.5-sigma
+            # margin at every step. Floored at the physical ``min_x_step``.
+            per_well_sigma = np.maximum(step_sigmas, max(acid_drop_between_sigma, 1e-6))
+            per_well_lower = np.maximum(nominal_drop - 2.5 * per_well_sigma, min_x_step)
             x_step = pm.TruncatedNormal(
                 "x_step",
                 mu=x_step_global[:, None],
                 sigma=max(acid_drop_between_sigma, 1e-6),
-                lower=min_drops[:, None],
+                lower=per_well_lower[:, None],
                 shape=(n_steps - 1, n_wells),
                 dims=("step_diff", "well"),
             )

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -2122,6 +2122,64 @@ def test_fit_binding_pymc_multi_hierarchical_uses_denoised_sigmas(
     assert not np.allclose(global_sigma, old_quadrature)
 
 
+def test_hierarchical_per_well_x_step_bound_uses_larger_sigma(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-well x_step lower bound is nominal - 2.5*max(step_sigmas, between).
+
+    Reusing the shared-walk ``min_drops`` (which uses only ``step_sigmas``)
+    places the wall ~1 sigma below the wider per-well mode when
+    ``acid_drop_between_sigma`` exceeds ``step_sigmas``, clipping it. The bound
+    must scale with the larger of the two per-step spreads.
+    """
+    xc = np.array([8.92, 8.80, 8.40, 7.90, 7.30, 6.60, 6.00])
+    x_errc = np.array([0.067, 0.017, 0.015, 0.016, 0.014, 0.015, 0.013])
+    y1 = binding_1site(xc, 7.2, 2.0, 1.0, is_ph=True)
+    y2 = binding_1site(xc, 7.2, 0.1, 1.0, is_ph=True)
+    ds = Dataset(
+        {"1": DataArray(xc, y1, x_errc=x_errc), "2": DataArray(xc, y2, x_errc=x_errc)},
+        is_ph=True,
+    )
+    fr_init = fit_binding_glob(ds)
+    scheme = PlateScheme()
+    scheme.names = {"ctrl": {"A01", "A02"}}
+    adb = 0.05  # deliberately > step_sigmas so max() differs from min_drops
+
+    _dir, _xs, nominal, step_sigmas, min_drops = bayes._pipetting_walk_params(  # noqa: SLF001
+        xc, x_errc, 1.0, min_x_step=0.2
+    )
+
+    captured: dict[str, object] = {}
+    orig_tn = pm.TruncatedNormal
+
+    def fake_tn(name: str, **kwargs: object) -> object:
+        if name == "x_step":
+            captured["lower"] = np.asarray(
+                cast("Any", kwargs["lower"]), dtype=float
+            ).ravel()
+            raise _StopBayesBuildError
+        return orig_tn(name, **kwargs)
+
+    monkeypatch.setattr(pm, "TruncatedNormal", fake_tn)
+
+    with pytest.raises(_StopBayesBuildError):
+        bayes.fit_binding_pymc_multi(
+            {"A01": fr_init, "A02": fr_init},
+            scheme,
+            n_xerr=1.0,
+            x_error_model="hierarchical_per_well",
+            acid_drop_between_sigma=adb,
+            sampler=SamplerConfig(n_samples=2, n_tune=1),
+        )
+
+    lower = cast("np.ndarray", captured["lower"])
+    expected = np.maximum(nominal - 2.5 * np.maximum(step_sigmas, adb), 0.2)
+    np.testing.assert_allclose(lower, expected)
+    # With adb > step_sigmas the per-well wall drops below the old min_drops.
+    assert np.all(expected <= min_drops + 1e-9)
+    assert np.any(expected < min_drops - 1e-6)
+
+
 @pytest.mark.parametrize(("between", "expect_well"), [(0.0, False), (0.03, True)])
 def test_fit_binding_pymc_multi_x_start_between_sigma_opt_in(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

In `x_error_model="hierarchical_per_well"`, the per-well pipetting step
`x_step ~ TruncatedNormal(x_step_global, acid_drop_between_sigma, lower=min_drops)`
reused the shared-walk lower bound `min_drops = nominal - 2.5*step_sigmas`, which
is calibrated for the narrow `step_sigmas` (~0.011). When `acid_drop_between_sigma`
is larger (e.g. 0.025), the wall sits only ~1 sigma below the per-well mode, so it
clips the per-well `x_step` posteriors and pins wells wanting a smaller step — the
"strong x_step anomaly" seen only in `hierarchical_per_well` (single-well and
`per_well` fits agree cleanly).

## Fix

Bound at `nominal - 2.5*max(step_sigmas, acid_drop_between_sigma)` (floored at
`min_x_step`) — a genuine 2.5-sigma margin matched to the larger per-step spread.
`max` matters: a between-sigma-only wall would *over*-truncate steps whose
`step_sigmas` dominates (e.g. the low-pH extreme with its large de-noised sigma).

## Validation (real L4, 92 wells, `acid_drop_between_sigma=0.025`)

Fraction of wells clipped at the wall, before -> after:

| step | 0 | 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|---|---|
| before | 0.28 | 0.29 | 0.01 | **0.96** | 0.00 | 0.00 |
| after | 0.00 | 0.00 | 0.00 | **0.27** | 0.00 | 0.00 |

Per-step room above the wall rises to 2.3-3.6 sigma; step 3 (the pH-transition
step) improves 0.96 -> 0.27, its residual being genuine data pull rather than a
prior artifact. `x_step_global` stays healthy, **0 divergences**, no speed change.
Regression test added on the bound formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)