### PR TITLE
refactor(bayes): drop hierarchical_per_well, default per-well x_start on

### DIFF
--- a/src/clophfit/fitting/bayes.py
+++ b/src/clophfit/fitting/bayes.py
@@ -961,6 +961,10 @@ _N_PH_REPLICATE_WELLS = 3
 # per-addition variance, so a noisy flat 3-well SD cannot pin a step to ~zero:
 # every 2 uL delivery carries a real, nonzero volume error.
 _MIN_PIPETTING_STEP_FRAC = 0.25
+# Default between-well scale for the per-well starting-x (x_start_well). Small and
+# nonzero so multi-well fits give each well its own x0, tightly anchored on the
+# shared plate x_start prior. Set to 0 for a single shared x_start.
+_DEFAULT_X_START_BETWEEN_SIGMA = 0.05
 
 
 def _pipetting_step_sigmas(x_errc_scaled: ArrayF) -> tuple[float, ArrayF]:
@@ -1016,9 +1020,8 @@ def _pipetting_walk_params(
 
     Single source of truth for the de-noised per-addition step derivation used
     by :func:`create_x_true` (single latent ``x_true``) and by the ``per_well``
-    and ``hierarchical_per_well`` x-error models in
-    :func:`fit_binding_pymc_multi`. Each caller builds its own RVs from these
-    arrays with the appropriate shape/dims.
+    x-error model in :func:`fit_binding_pymc_multi`. Each caller builds its own
+    RVs from these arrays with the appropriate shape/dims.
 
     Parameters
     ----------
@@ -1933,7 +1936,7 @@ def _per_well_fit_results_from_trace(
     fit_results: Mapping[str, FitResult[MiniT]],
     scheme: PlateScheme,
     *,
-    x_error_model: Literal["deterministic", "per_well", "hierarchical_per_well"],
+    x_error_model: Literal["deterministic", "per_well"],
     global_p_names: typing.Iterable[str] = (),
 ) -> dict[str, FitResult[xr.DataTree]]:
     """Reconstruct per-well fit results from a shared multi-well trace."""
@@ -1943,7 +1946,7 @@ def _per_well_fit_results_from_trace(
         if fr.dataset is None:
             continue
         ctr = next((name for name, wells in scheme.names.items() if key in wells), "")
-        well_key = key if x_error_model in {"per_well", "hierarchical_per_well"} else ""
+        well_key = key if x_error_model == "per_well" else ""
         ds = copy.deepcopy(fr.dataset)
         per_well_results[key] = extract_fit(
             key,
@@ -2362,10 +2365,7 @@ def fit_binding_pymc_multi_residual_refit(  # noqa: C901, PLR0912, PLR0913
     n_tune: int | None = None,
     target_accept: float | None = None,
     max_treedepth: int | None = None,
-    x_error_model: Literal[
-        "deterministic", "per_well", "hierarchical_per_well"
-    ] = "deterministic",
-    acid_drop_between_sigma: float = 0.005,
+    x_error_model: Literal["deterministic", "per_well"] = "deterministic",
     ctr_free_k: bool = False,
     shared_ye_mags: bool = False,
     outlier_threshold: float = 3.0,
@@ -2417,10 +2417,8 @@ def fit_binding_pymc_multi_residual_refit(  # noqa: C901, PLR0912, PLR0913
         NUTS target acceptance probability.
     max_treedepth : int | None
         Maximum NUTS tree depth.
-    x_error_model : Literal["deterministic", "per_well", "hierarchical_per_well"]
+    x_error_model : Literal["deterministic", "per_well"]
         Latent-x error model forwarded to :func:`fit_binding_pymc_multi`.
-    acid_drop_between_sigma : float, optional
-        Between-well acid-drop prior scale.
     ctr_free_k : bool, optional
         Allow control wells to have free K values in the multi-well model.
     shared_ye_mags : bool, optional
@@ -2516,7 +2514,6 @@ def fit_binding_pymc_multi_residual_refit(  # noqa: C901, PLR0912, PLR0913
         n_xerr=n_xerr,
         min_x_step=min_x_step,
         x_error_model=x_error_model,
-        acid_drop_between_sigma=acid_drop_between_sigma,
         ctr_free_k=ctr_free_k,
         well_noise_scale=well_noise_scale,
         shared_well_noise_scale=shared_well_noise_scale,
@@ -2566,7 +2563,6 @@ def fit_binding_pymc_multi_residual_refit(  # noqa: C901, PLR0912, PLR0913
         n_xerr=n_xerr if final_n_xerr is None else final_n_xerr,
         min_x_step=min_x_step,
         x_error_model=x_error_model,
-        acid_drop_between_sigma=acid_drop_between_sigma,
         ctr_free_k=ctr_free_k,
         well_noise_scale=well_noise_scale,
         shared_well_noise_scale=shared_well_noise_scale,
@@ -2907,11 +2903,8 @@ def fit_binding_pymc_multi(  # noqa: C901, PLR0912, PLR0913, PLR0915
     n_sd: float = 5.0,
     n_xerr: float = 1.0,
     min_x_step: float = 0.2,
-    x_error_model: Literal[
-        "deterministic", "per_well", "hierarchical_per_well"
-    ] = "deterministic",
-    acid_drop_between_sigma: float = 0.005,
-    x_start_between_sigma: float = 0.0,
+    x_error_model: Literal["deterministic", "per_well"] = "deterministic",
+    x_start_between_sigma: float = _DEFAULT_X_START_BETWEEN_SIGMA,
     ctr_free_k: bool = False,
     sample_ppc: bool = False,
     per_well_ye_mags: bool | None = None,
@@ -2940,21 +2933,16 @@ def fit_binding_pymc_multi(  # noqa: C901, PLR0912, PLR0913, PLR0915
         Scaling factor applied to x-value uncertainties.
     min_x_step : float
         Minimum inferred change in ``x`` between consecutive titration steps.
-    x_error_model : Literal["deterministic", "per_well", "hierarchical_per_well"]
+    x_error_model : Literal["deterministic", "per_well"]
         Model for x-error propagation across wells. ``"deterministic"`` shares
-        one ``x_true``; ``"per_well"`` gives each well its own cumulative
-        additions; ``"hierarchical_per_well"`` uses an acid-addition formulation.
-    acid_drop_between_sigma : float
-        Fixed between-well scale for the per-well ``x_step`` variation used by
-        ``"hierarchical_per_well"`` (set to the experimental tolerance).
+        one latent ``x_true`` walk across all wells; ``"per_well"`` gives each
+        well its own cumulative-additions walk.
     x_start_between_sigma : float
-        Fixed between-well scale for the starting x (pH). ``0.0`` (default)
-        shares a single ``x_start`` anchor across all wells — appropriate when
-        the plate shares one buffer and one pre-addition reading. A positive
-        value adds an opt-in per-well term ``x_start_well ~ Normal(x_start,
-        x_start_between_sigma)`` (common-mode global anchor plus independent
-        per-well jitter), a safety valve for genuine per-well starting-pH
-        offsets. Applies to ``"per_well"`` and ``"hierarchical_per_well"``.
+        Fixed between-well scale for the starting x (pH). Defaults to a small
+        nonzero value, so each well gets its own ``x_start_well ~ Normal(
+        x_start, x_start_between_sigma)`` tightly anchored on the shared plate
+        ``x_start`` prior (common-mode anchor plus independent per-well jitter).
+        Set to ``0.0`` for a single shared ``x_start`` across all wells.
     ctr_free_k : bool
         If ``True``, each control replicate gets an independent flat K prior
         instead of a shared control K.
@@ -3103,61 +3091,15 @@ def fit_binding_pymc_multi(  # noqa: C901, PLR0912, PLR0913, PLR0915
         else:
             pi_outliers, outlier_inflate = {}, None
 
-        if x_error_model == "hierarchical_per_well" and n_xerr > 0:
-            if not np.all(np.diff(xc) < 0):
-                msg = (
-                    "hierarchical_per_well acid-addition model expects "
-                    "decreasing pH values."
-                )
-                raise ValueError(msg)
-
-            # Shared de-noised pipetting derivation. pH decreases as acid is
-            # added, so direction is -1: step_nominal are the positive acid
-            # drops and step_sigmas the per-addition pipetting sigmas (read
-            # noise removed, isotonic-regularized), matching create_x_true. The
-            # global-drop prior is now the pipetting-process sigma rather than
-            # the quadrature measurement-difference sigma, and x_start is
-            # anchored at the de-noised standard error of the step-0 mean.
-            _direction, x_start_sigma, nominal_drop, step_sigmas, min_drops = (
-                _pipetting_walk_params(xc, x_errc, n_xerr, min_x_step=min_x_step)
+        if x_error_model not in {"deterministic", "per_well"}:
+            msg = (
+                f"Unknown x_error_model {x_error_model!r}; valid options are "
+                "'deterministic' and 'per_well' "
+                "('hierarchical_per_well' was removed)."
             )
+            raise ValueError(msg)
 
-            x_start = _build_multi_x_start(xc, x_start_sigma, x_start_between_sigma)
-
-            x_step_global = pm.TruncatedNormal(
-                "x_step_global",
-                mu=nominal_drop,
-                sigma=np.maximum(step_sigmas, 1e-6),
-                lower=min_drops,
-                dims="step_diff",
-            )
-
-            # Fixed between-well scale — do not sample a variance parameter;
-            # the centered funnel destroys sampler performance.
-            x_step = pm.TruncatedNormal(
-                "x_step",
-                mu=x_step_global[:, None],
-                sigma=max(acid_drop_between_sigma, 1e-6),
-                lower=min_drops[:, None],
-                shape=(n_steps - 1, n_wells),
-                dims=("step_diff", "well"),
-            )
-
-            cumulative_drop = pm.math.cumsum(x_step, axis=0)
-
-            # Use ones_like on a slice to inherit the well-dimension shape.
-            start_row = pt.ones_like(x_step[:1, :]) * x_start  # type: ignore[no-untyped-call]
-            x_matrix = pm.math.concatenate(
-                [start_row, x_start - cumulative_drop], axis=0
-            )
-
-            x_w_all = pm.Deterministic(
-                "x_true",
-                x_matrix,
-                dims=("step", "well"),
-            )
-
-        elif x_error_model == "per_well" and n_xerr > 0:
+        if x_error_model == "per_well" and n_xerr > 0:
             direction, x_start_sigma, step_nominal, step_sigmas, min_steps = (
                 _pipetting_walk_params(xc, x_errc, n_xerr, min_x_step=min_x_step)
             )
@@ -3178,7 +3120,7 @@ def fit_binding_pymc_multi(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 dims=("step", "well"),
             )
 
-        elif x_error_model in {"per_well", "hierarchical_per_well"}:
+        elif x_error_model == "per_well":
             x_matrix = np.empty((n_steps, n_wells), dtype=float)
             for w_idx, key in enumerate(wells_list):
                 well_ds = fit_results[key].dataset

--- a/src/clophfit/fitting/bayes_config.py
+++ b/src/clophfit/fitting/bayes_config.py
@@ -73,10 +73,9 @@ class SamplerConfig:
         Number of posterior draws per chain.
     nuts_sampler : str
         NUTS backend. Defaults to ``"nutpie"`` — its warmup/mass-matrix
-        adaptation handles the funnel geometry of the hierarchical latent-x
-        model, where the built-in ``"pymc"`` sampler diverges heavily and fails
-        to converge. ``"pymc"`` (built-in NUTS, Numba backend) is fine and
-        marginally faster on simple deterministic-x fits. ``"default"`` lets
+        adaptation is robust on the multi-well latent-x geometry. ``"pymc"``
+        (built-in NUTS, Numba backend) is fine and marginally faster on simple
+        deterministic-x fits. ``"default"`` lets
         PyMC auto-select whatever is installed; ``"numpyro"``/``"blackjax"``
         (JAX/GPU) request those explicitly but are unusable here (numpyro lacks
         an ``erfcx`` implementation; blackjax is incompatible with PyMC 6.1).

--- a/src/clophfit/fitting/model_validation.py
+++ b/src/clophfit/fitting/model_validation.py
@@ -1256,7 +1256,6 @@ def trace_diagnostics(
             "K_ctr",
             "x_start",
             "x_true",
-            "x_step_global",
             "x_step",
             "ye_mag",
             "rel_error",

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -2044,20 +2044,20 @@ def test_fit_binding_pymc_multi_zero_xerr_keeps_per_well_x(
         bayes.fit_binding_pymc_multi(
             {"A01": ds_a, "A02": ds_b},
             scheme,
-            x_error_model="hierarchical_per_well",
+            x_error_model="per_well",
             n_xerr=0.0,
             noise=NoiseConfig.structured(noise_model=noise_model),
             sampler=SamplerConfig(n_samples=2, n_tune=1),
         )
 
 
-def test_fit_binding_pymc_multi_hierarchical_uses_denoised_sigmas(
+def test_fit_binding_pymc_multi_per_well_uses_denoised_sigmas(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Pin hierarchical_per_well to the de-noised pipetting derivation.
+    """Pin per_well to the de-noised pipetting derivation.
 
     ``x_start`` must be anchored at the isotonic standard error of the step-0
-    mean and ``x_step_global`` must use the isotonic per-addition pipetting
+    mean and the per-well ``x_step`` must use the isotonic per-addition pipetting
     sigma — not the pre-fix read-noise-inflated raw / quadrature values. This
     guards against a silent regression to the old formulation.
     """
@@ -2089,9 +2089,9 @@ def test_fit_binding_pymc_multi_hierarchical_uses_denoised_sigmas(
         return orig_normal(name, **kwargs)
 
     def fake_truncnormal(name: str, **kwargs: object) -> object:
-        if name == "x_step_global":
-            captured["global_sigma"] = np.asarray(
-                cast("Any", kwargs["sigma"]), dtype=float
+        if name == "x_step":
+            captured["step_sigma"] = np.ravel(
+                np.asarray(cast("Any", kwargs["sigma"]), dtype=float)
             )
             raise _StopBayesBuildError
         return orig_truncnormal(name, **kwargs)
@@ -2104,22 +2104,22 @@ def test_fit_binding_pymc_multi_hierarchical_uses_denoised_sigmas(
             {"A01": fr_init, "A02": fr_init},
             scheme,
             n_xerr=1.0,
-            x_error_model="hierarchical_per_well",
+            x_error_model="per_well",
             sampler=SamplerConfig(n_samples=2, n_tune=1),
         )
 
     x_start_sigma = cast("float", captured["x_start_sigma"])
-    global_sigma = cast("np.ndarray", captured["global_sigma"])
+    step_sigma = cast("np.ndarray", captured["step_sigma"])
     # x_start anchored at the de-noised SE of the step-0 mean ...
     assert x_start_sigma == pytest.approx(max(exp_x_start_sigma, 1e-6))
     # ... far below the raw leading 3-well SD it used to inherit.
     assert x_start_sigma < x_errc[0]
 
-    # x_step_global uses the isotonic per-addition pipetting sigma ...
-    np.testing.assert_allclose(global_sigma, np.maximum(exp_step_sigmas, 1e-6))
+    # per-well x_step uses the isotonic per-addition pipetting sigma ...
+    np.testing.assert_allclose(step_sigma, np.maximum(exp_step_sigmas, 1e-6))
     # ... not the old quadrature measured-difference sigma.
     old_quadrature = np.sqrt(x_errc[:-1] ** 2 + x_errc[1:] ** 2)
-    assert not np.allclose(global_sigma, old_quadrature)
+    assert not np.allclose(step_sigma, old_quadrature)
 
 
 @pytest.mark.parametrize(("between", "expect_well"), [(0.0, False), (0.03, True)])
@@ -2172,6 +2172,23 @@ def test_fit_binding_pymc_multi_x_start_between_sigma_opt_in(
 
     assert "x_start" in normal_names
     assert ("x_start_well" in normal_names) is expect_well
+
+
+def test_fit_binding_pymc_multi_rejects_removed_hierarchical_model() -> None:
+    """The removed hierarchical_per_well x_error_model raises a clear error."""
+    xc = np.array([6.0, 6.6, 7.3, 8.0])
+    y = binding_1site(xc, 7.0, 1.0, 2.0, is_ph=True)
+    ds = Dataset({"1": DataArray(xc, y)}, is_ph=True)
+    fr_init = fit_binding_glob(ds)
+    scheme = PlateScheme()
+    scheme.names = {"ctrl": {"A01"}}
+    with pytest.raises(ValueError, match="hierarchical_per_well"):
+        bayes.fit_binding_pymc_multi(
+            {"A01": fr_init},
+            scheme,
+            x_error_model="hierarchical_per_well",  # type: ignore[arg-type]
+            sampler=SamplerConfig(n_samples=2, n_tune=1),
+        )
 
 
 def test_extract_fit_accepts_multifitresult_deterministic() -> None:


### PR DESCRIPTION
## Motivation

Standardize the multi-well x-error model on `per_well`. On real L4, `per_well`
matches the single-well gold standard (x_true within 0.005 pH), while
`hierarchical_per_well` broadened and shifted x_true by up to ~0.12 pH via
pooling and carried a funnel geometry + wall-truncation — cost with no benefit
when the data already resolve each well.

## Changes

**Remove `hierarchical_per_well`:**
- Delete the `x_step_global` + per-well-correction branch.
- Remove the orphaned `acid_drop_between_sigma` param (both multi entry points and passthroughs) and the dead `x_step_global` trace-summary entry.
- Drop `hierarchical_per_well` from every `x_error_model` Literal.
- Passing `x_error_model="hierarchical_per_well"` now raises a clear `ValueError` naming the valid options (`deterministic`, `per_well`).

**Default per-well `x_start` on:**
- `x_start_between_sigma` now defaults to `_DEFAULT_X_START_BETWEEN_SIGMA = 0.05` (was 0.0), so each well gets its own `x_start_well ~ Normal(x_start, sigma)` tightly anchored on the shared plate `x_start` prior. Set to `0.0` for a single shared x_start.

## Validation (real L4, per_well + mixture)

Per-well x0 appears by default: `x_start_well` present, across-well SD 0.010, anchored on the shared 8.885 prior; **0 divergences**.

Converts the denoised-sigmas guard test to `per_well`; adds a removed-model error test. 289 tests pass; ruff/mypy clean.

## Note

This supersedes #1393 (a truncation fix for the now-removed hierarchical model) — that PR should be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)