### PR TITLE
feat(data): add mask_steps / mask_label_steps for per-label step exclusion

### DIFF
--- a/src/clophfit/fitting/data_structures.py
+++ b/src/clophfit/fitting/data_structures.py
@@ -29,7 +29,7 @@ from clophfit.clophfit_types import MiniT as MiniT  # noqa: PLC0414
 from .errors import InvalidDataError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     import xarray as xr
     from lmfit import Parameters  # type: ignore[import-untyped]
@@ -99,6 +99,23 @@ class DataArray:
     def mask(self, mask: ArrayMask) -> None:
         """Only boolean where yc is not nan are considered."""
         self._mask = mask & ~np.isnan(self.yc)
+
+    def mask_steps(self, steps: Iterable[int]) -> None:
+        """Exclude the given step indices from the fit, in place.
+
+        Masks positions in the original (unmasked) array while preserving any
+        existing mask. Out-of-range indices are ignored.
+
+        Parameters
+        ----------
+        steps : Iterable[int]
+            Step indices to mask out (e.g. ``[0, 6]`` for the pH extremes).
+        """
+        m = self.mask.copy()
+        for s in steps:
+            if 0 <= int(s) < m.size:
+                m[int(s)] = False
+        self.mask = m
 
     @property
     def x(self) -> ArrayF:
@@ -269,6 +286,32 @@ class Dataset(UserDict[str, DataArray]):
             end_idx = start_idx + len(da.y)
             da.mask[da.mask] &= combined_mask[start_idx:end_idx]
             start_idx = end_idx
+
+    def mask_label_steps(self, label: str, steps: Iterable[int]) -> None:
+        """Exclude step indices for one label's DataArray, in place.
+
+        Drops a known-bad measurement region on a single channel without
+        touching the others — e.g. the extreme-pH endpoints on a noisy,
+        boosted-gain label::
+
+            ds.mask_label_steps("1", [0, 6])
+
+        Parameters
+        ----------
+        label : str
+            Label key into the dataset.
+        steps : Iterable[int]
+            Step indices to mask out.
+
+        Raises
+        ------
+        KeyError
+            If *label* is not present in the dataset.
+        """
+        if label not in self:
+            msg = f"Label {label!r} not in dataset; have {list(self)}."
+            raise KeyError(msg)
+        self[label].mask_steps(steps)
 
     def copy(self, keys: list[str] | set[str] | None = None) -> Dataset:
         """Return a copy of the Dataset.

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -411,6 +411,23 @@ def test_dataarray_masking() -> None:
     assert np.array_equal(da.x_errc, np.array([]))
 
 
+def test_mask_label_steps_excludes_only_that_label() -> None:
+    """mask_label_steps drops given steps for one label, leaving others intact."""
+    x = np.array([9.0, 8.0, 7.0, 6.0, 5.0])
+    y = np.array([2.0, 1.8, 1.5, 1.2, 1.0])
+    ds = Dataset({"1": DataArray(x, y), "2": DataArray(x, y * 2)}, is_ph=True)
+
+    ds.mask_label_steps("1", [0, 4])  # drop the pH extremes on label 1 only
+    np.testing.assert_array_equal(ds["1"].x, np.array([8.0, 7.0, 6.0]))
+    np.testing.assert_array_equal(ds["2"].x, x)  # label 2 untouched
+
+    # out-of-range indices are ignored; missing label raises
+    ds["1"].mask_steps([99, -1])
+    np.testing.assert_array_equal(ds["1"].x, np.array([8.0, 7.0, 6.0]))
+    with pytest.raises(KeyError, match="Label '3' not in dataset"):
+        ds.mask_label_steps("3", [0])
+
+
 def test_dataarray_initialization_failure() -> None:
     """Test for length mismatch error during DataArray initialization."""
     xc = np.array([1, 2, 3])


### PR DESCRIPTION
Adds a one-liner to drop specific step indices on a single channel without touching the others — e.g. excluding the extreme-pH endpoints on a noisy, boosted-gain label:

```python
ds.mask_label_steps("1", [0, 6])   # drop pH extremes on label 1 only
```

- `DataArray.mask_steps(steps)` — mask given step indices in place, preserving the existing mask; out-of-range indices ignored.
- `Dataset.mask_label_steps(label, steps)` — the same for one label's `DataArray`; raises `KeyError` on an unknown label.

Motivated by a diagnosed label-1 instrumental artifact at the pH extremes (arch-shaped, proportional-to-signal residual, present on both L4 and L2, absent on the reference channel). K-stability checks confirmed masking those points shifts K by << its posterior SD on both plates, so this is a clean-residuals/QC tool, not a K correction.

Validated end-to-end on real L2 (the masked refit ran through the helper). ruff/mypy clean; unit test covers per-label isolation, out-of-range indices, and the missing-label error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)