### PR TITLE
feat(prtecan): Titration.fit_plate returning TitrationResults with unified .residuals

### DIFF
--- a/benchmarks/tecan_real_data_benchmark.py
+++ b/benchmarks/tecan_real_data_benchmark.py
@@ -340,10 +340,9 @@ def _fit_real_curve_with_titration(
     tit.scheme.names = {grp: keys for grp, keys in tit.scheme.names.items() if keys}
 
     if result_attr in ("result_multi_noise_mcmc", "result_multi_noise_xrw_mcmc", "result_multi_mcmc"):
-        from clophfit.fitting.pipeline import fit_plate
         from clophfit.fitting.bayes import fit_binding_pymc_multi, extract_fit
 
-        results = fit_plate(datasets, method=combination.prefit)
+        results = tit.fit_plate(datasets, method=combination.prefit).results
         x_error_model = "per_well" if "xrw" in result_attr else "deterministic"
         noise_model: PlateNoiseModel | None = None
         if "noise" in result_attr:
@@ -369,14 +368,13 @@ def _fit_real_curve_with_titration(
                 break
         return multi_result.results[requested_well]
     else:
-        from clophfit.fitting.pipeline import fit_plate
         method_map = {"result_global": "lm", "result_odr": "odr", "result_mcmc": "mcmc"}
         method = method_map.get(result_attr, combination.prefit)
 
         if method == "mcmc":
-            results = fit_plate(datasets, method="mcmc", n_samples=tit.params.n_mcmc_samples, n_tune=tit.params.n_mcmc_samples // 2)
+            results = tit.fit_plate(datasets, method="mcmc", n_samples=tit.params.n_mcmc_samples, n_tune=tit.params.n_mcmc_samples // 2)
         else:
-            results = fit_plate(datasets, method=method)
+            results = tit.fit_plate(datasets, method=method)
 
         return results[requested_well]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,7 @@ exclude_patterns = [
     "Thumbs.db",
     ".DS_Store",
     "jupyter_execute",
+    "superpowers",  # internal design specs, not published documentation
     "**/.virtual_documents",
     "**/.ipynb_checkpoints",
 ]

--- a/docs/superpowers/plans/2026-07-17-plate-fit-residuals.md
+++ b/docs/superpowers/plans/2026-07-17-plate-fit-residuals.md
@@ -1,0 +1,1180 @@
+# Plate-Fit Residuals Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give plate-level fits a `.residuals` accessor matching `FitResult.residuals` and `MultiFitResult.residuals`, by moving `fit_plate` onto `Titration` and returning `TitrationResults`.
+
+**Architecture:** `fit_plate` moves from `clophfit.fitting.pipeline` (a module for multistage FGLS orchestration, which it never belonged to) onto `Titration` as a method returning `TitrationResults` — legal because `prtecan → fitting` is the established dependency direction. The residual-settings auto-detection currently duplicated in two `residual_table` bodies is extracted into a `ResidualsMixin`, which then serves `FitResult`, `MultiFitResult`, and `TitrationResults`. `MultiFitResult` is untouched structurally: it is a trace proxy, not a plate container.
+
+**Tech Stack:** Python 3.12+ (PEP 695 generics), pandas, lmfit, PyMC, pytest, ruff, mypy, uv.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-plate-fit-residuals-design.md`
+
+## Global Constraints
+
+- Run every command through `uv run` (e.g. `uv run pytest`). Never call bare `pip`/`python`.
+- Type hints on all public functions and methods; must pass `uv run mypy`.
+- Numpy-style docstrings on all public API (`ruff` is configured with `convention = "numpy"`).
+- Format and lint with `ruff` only: `uv run ruff format` / `uv run ruff check`. Never `black` or `isort`.
+- `line-length = 88`, `target-version = "py312"`.
+- Do not reformat code unrelated to the task at hand.
+- Do not modify `pyproject.toml`.
+- **Do not touch `prtecan_devel.ipynb`.** It has uncommitted user changes and is excluded from both ruff (`extend-exclude`) and the docs build. Its `fit_plate` calls are the user's to migrate.
+- `docs/tutorials/prtecan.ipynb` **is** linted by ruff (`extend-include = ["*.ipynb"]`) and **is** executed by the docs build (`nb_execution_allow_errors = False`). It must be migrated before `pipeline.fit_plate` is deleted, or CI fails.
+- Never edit `docs/jupyter_execute/**` or `docs/tutorials/.virtual_documents/**` — generated artifacts, excluded via `conf.py`.
+
+______________________________________________________________________
+
+### Task 1: Module-level imports in `data_structures.py`
+
+Removes the lazy imports inside `FitResult.residual_table`. They exist only because they used the **package-attribute form** (`from clophfit.fitting import model_validation`), which needs `fitting/__init__.py` to have finished binding that attribute — and `__init__` eagerly imports `bayes` → … → `data_structures`. The **submodule-direct form** avoids this. The graph is acyclic: `model_validation` → `residuals` (imports nothing from `clophfit`), `models` → `clophfit_types`, and `model_validation` never references `data_structures`.
+
+**Files:**
+
+- Modify: `src/clophfit/fitting/data_structures.py:27-29` (imports), `:568-591` (`residual_table` body)
+- Create: `tests/test_imports.py`
+
+**Interfaces:**
+
+- Consumes: nothing.
+
+- Produces: module-level names in `data_structures`: `residuals_from_fit_results`, `robust_likelihood_from_trace`, `robust_settings_from_trace`, `STUDENT_T_NU`, `binding_1site`. Task 2 relies on these being importable at module scope.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_imports.py`:
+
+```python
+"""Cold-import regression tests.
+
+Each import runs in a fresh interpreter so partially-initialized-package
+regressions surface instead of being masked by an already-populated
+``sys.modules``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _cold_import(statement: str) -> None:
+    subprocess.run([sys.executable, "-c", statement], check=True)
+
+
+def test_cold_import_fitting_package() -> None:
+    """Importing the package triggers the eager ``__init__`` chain."""
+    _cold_import("import clophfit.fitting")
+
+
+def test_cold_import_data_structures_first() -> None:
+    """Importing the submodule first must not hit a partial parent package."""
+    _cold_import("import clophfit.fitting.data_structures")
+
+
+def test_cold_import_prtecan() -> None:
+    """prtecan imports fitting at module level; it must stay importable."""
+    _cold_import("import clophfit.prtecan")
+```
+
+- [ ] **Step 2: Run the test to verify it passes on the current tree**
+
+Run: `uv run pytest tests/test_imports.py -v`
+Expected: 3 passed. This is a characterization test — it pins current behaviour so Step 3 cannot silently break imports.
+
+- [ ] **Step 3: Add the module-level imports**
+
+In `src/clophfit/fitting/data_structures.py`, after the existing line 29 (`from .errors import InvalidDataError`), add:
+
+```python
+from clophfit.fitting.model_validation import (
+    STUDENT_T_NU,
+    residuals_from_fit_results,
+    residuals_from_multifit,
+    robust_likelihood_from_trace,
+    robust_settings_from_trace,
+)
+from clophfit.fitting.models import binding_1site
+```
+
+Use the absolute submodule-direct form exactly as written — `from clophfit.fitting import model_validation` will fail here, and that failure is the reason the lazy import existed.
+
+- [ ] **Step 4: Delete the lazy imports and rewrite the call**
+
+In `FitResult.residual_table`, delete these two lines (currently 568-569):
+
+```python
+        from clophfit.fitting import model_validation  # noqa: PLC0415
+        from clophfit.fitting.models import binding_1site  # noqa: PLC0415
+```
+
+Then drop the `model_validation.` prefix from the five call sites in that method body, so it reads:
+
+```python
+        bfunc = binding_1site if binding_function is None else binding_function
+        residual_likelihood: str | None = None
+        if robust is None:
+            residual_likelihood = robust_likelihood_from_trace(self.mini)
+            robust, detected_nu = robust_settings_from_trace(self.mini)
+            if student_t_nu is None:
+                student_t_nu = detected_nu
+        if student_t_nu is None:
+            student_t_nu = STUDENT_T_NU
+        return residuals_from_fit_results(
+            {well: self},
+            trace_id="",
+            binding_function=bfunc,
+            robust=robust,
+            student_t_nu=student_t_nu,
+            outlier_threshold=outlier_threshold,
+            trace=self.mini,
+            residual_likelihood=residual_likelihood,
+        )
+```
+
+Apply the same treatment to `MultiFitResult.residual_table` (currently 650-674): delete its two lazy import lines and unqualify, keeping its terminal call as `residuals_from_multifit(self, ...)`.
+
+- [ ] **Step 5: Run the tests to verify nothing broke**
+
+Run: `uv run pytest tests/test_imports.py tests/test_residuals.py tests/test_model_validation_smoke.py -q`
+Expected: all pass. `test_model_validation_smoke.py::...` exercises `residual_table(well="A01")` at lines 839, 860, 888.
+
+- [ ] **Step 6: Lint and typecheck**
+
+Run: `uv run ruff check src/clophfit/fitting/data_structures.py tests/test_imports.py && uv run mypy src/clophfit/fitting/data_structures.py`
+Expected: `All checks passed!` and no mypy errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/clophfit/fitting/data_structures.py tests/test_imports.py
+git commit -m "refactor(imports): hoist data_structures residual imports to module level"
+```
+
+______________________________________________________________________
+
+### Task 2: `ResidualsMixin` for `FitResult` and `MultiFitResult`
+
+Extracts the ~12-line auto-detect dance duplicated across `FitResult.residual_table` and `MultiFitResult.residual_table`. Each class keeps its **own** `residual_table` signature — `FitResult` takes `well: str = ""` (used by `test_model_validation_smoke.py:839,860,888`) and the others do not, so a single shared signature would either drop `well` or force untyped `**kwargs`.
+
+**Files:**
+
+- Modify: `src/clophfit/fitting/data_structures.py` (add mixin above `FitResult`; edit `FitResult` and `MultiFitResult`)
+- Test: `tests/test_residuals.py`
+
+**Interfaces:**
+
+- Consumes: module-level `robust_likelihood_from_trace`, `robust_settings_from_trace`, `STUDENT_T_NU`, `binding_1site` from Task 1.
+
+- Produces: `ResidualsMixin` with `residuals` (cached_property) and `_resolve_residual_settings(trace, *, binding_function=None, robust=None, student_t_nu=None) -> _ResidualSettings`, where `_ResidualSettings` is a `NamedTuple(binding_function, robust, student_t_nu, residual_likelihood)`. Task 3 subclasses this mixin.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_residuals.py`:
+
+```python
+def test_residuals_mixin_resolves_classical_fit_as_normal() -> None:
+    """A classical fit has no trace, so it standardizes as Normal."""
+    from clophfit.fitting.data_structures import ResidualsMixin
+
+    settings = ResidualsMixin._resolve_residual_settings(None)  # noqa: SLF001
+
+    assert settings.robust is False
+    assert settings.student_t_nu == 3.0
+    assert settings.residual_likelihood == "normal"
+
+
+def test_residuals_mixin_honours_explicit_robust() -> None:
+    """An explicit robust flag skips auto-detection and its likelihood label."""
+    from clophfit.fitting.data_structures import ResidualsMixin
+
+    settings = ResidualsMixin._resolve_residual_settings(  # noqa: SLF001
+        None, robust=True, student_t_nu=5.0
+    )
+
+    assert settings.robust is True
+    assert settings.student_t_nu == 5.0
+    assert settings.residual_likelihood is None
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_residuals.py -k residuals_mixin -v`
+Expected: FAIL with `ImportError: cannot import name 'ResidualsMixin'`.
+
+- [ ] **Step 3: Add the mixin**
+
+In `src/clophfit/fitting/data_structures.py`, immediately above `@dataclass class FitResult[MiniType: MiniProtocol]:` (currently line 488), add:
+
+```python
+class _ResidualSettings(NamedTuple):
+    """Resolved settings for building a canonical residual table."""
+
+    binding_function: Callable[..., object]
+    robust: bool
+    student_t_nu: float
+    residual_likelihood: str | None
+
+
+class ResidualsMixin:
+    """Shared canonical-residual accessor for fit-result containers.
+
+    Subclasses must implement :meth:`residual_table`. They may add extra
+    keyword-only parameters to it (``FitResult`` adds ``well``).
+    """
+
+    @cached_property
+    def residuals(self) -> pd.DataFrame:
+        """Canonical per-observation residual table for this fit.
+
+        Lazily computed, cached, and returned in the schema shared across the
+        package (``clophfit.fitting.model_validation.RESIDUAL_TABLE_COLUMNS``:
+        ``raw_res``, ``yhat``, ``sigma``, ``std_res``, …). Robustness is
+        auto-detected. Use :meth:`residual_table` to override the model or the
+        robust settings.
+        """
+        return self.residual_table()
+
+    def residual_table(self) -> pd.DataFrame:
+        """Compute the canonical residual table. Implemented by subclasses."""
+        raise NotImplementedError
+
+    @staticmethod
+    def _resolve_residual_settings(
+        trace: object,
+        *,
+        binding_function: Callable[..., object] | None = None,
+        robust: bool | None = None,
+        student_t_nu: float | None = None,
+    ) -> _ResidualSettings:
+        """Resolve model and standardization settings for a residual table.
+
+        Parameters
+        ----------
+        trace : object
+            PyMC trace to auto-detect robustness from, or ``None`` for a
+            classical fit (which resolves to Normal standardization).
+        binding_function : Callable[..., object] | None
+            Model evaluated for ``yhat``; defaults to ``binding_1site``.
+        robust : bool | None
+            Force the Student-t standardization of ``std_res``. ``None``
+            auto-detects from *trace*.
+        student_t_nu : float | None
+            Student-t degrees of freedom. ``None`` uses the detected/default.
+
+        Returns
+        -------
+        _ResidualSettings
+            The resolved binding function, robust flag, nu, and likelihood label.
+        """
+        bfunc = binding_1site if binding_function is None else binding_function
+        residual_likelihood: str | None = None
+        if robust is None:
+            residual_likelihood = robust_likelihood_from_trace(trace)
+            robust, detected_nu = robust_settings_from_trace(trace)
+            if student_t_nu is None:
+                student_t_nu = detected_nu
+        if student_t_nu is None:
+            student_t_nu = STUDENT_T_NU
+        return _ResidualSettings(bfunc, robust, student_t_nu, residual_likelihood)
+```
+
+Add `NamedTuple` to the `typing` import on line 18, so it reads:
+
+```python
+from typing import TYPE_CHECKING, NamedTuple, Protocol, TypeVar, cast, runtime_checkable
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_residuals.py -k residuals_mixin -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Apply the mixin to both classes**
+
+Change the `FitResult` declaration (currently line 489) to:
+
+```python
+class FitResult[MiniType: MiniProtocol](ResidualsMixin):
+```
+
+Delete its `residuals` cached_property (currently 525-535) — it now comes from the mixin — and replace the body of `residual_table` (keeping its existing docstring and signature, including `well: str = ""`) with:
+
+```python
+        settings = self._resolve_residual_settings(
+            self.mini,
+            binding_function=binding_function,
+            robust=robust,
+            student_t_nu=student_t_nu,
+        )
+        return residuals_from_fit_results(
+            {well: self},
+            trace_id="",
+            binding_function=settings.binding_function,
+            robust=settings.robust,
+            student_t_nu=settings.student_t_nu,
+            outlier_threshold=outlier_threshold,
+            trace=self.mini,
+            residual_likelihood=settings.residual_likelihood,
+        )
+```
+
+Change the `MultiFitResult` declaration (currently line 595) to:
+
+```python
+class MultiFitResult(ResidualsMixin):
+```
+
+Delete its `residuals` cached_property (currently 613-622) and replace its `residual_table` body (keeping signature and docstring) with:
+
+```python
+        settings = self._resolve_residual_settings(
+            self.trace,
+            binding_function=binding_function,
+            robust=robust,
+            student_t_nu=student_t_nu,
+        )
+        return residuals_from_multifit(
+            self,
+            trace_id="",
+            binding_function=settings.binding_function,
+            robust=settings.robust,
+            student_t_nu=settings.student_t_nu,
+            outlier_threshold=outlier_threshold,
+            residual_likelihood=settings.residual_likelihood,
+        )
+```
+
+- [ ] **Step 6: Run the full residual test suites**
+
+Run: `uv run pytest tests/test_residuals.py tests/test_model_validation_smoke.py tests/test_imports.py -q`
+Expected: all pass, including the pre-existing `residual_table(well="A01")` tests.
+
+- [ ] **Step 7: Lint and typecheck**
+
+Run: `uv run ruff check src/clophfit/fitting/data_structures.py tests/test_residuals.py && uv run mypy src/clophfit/fitting/data_structures.py`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/clophfit/fitting/data_structures.py tests/test_residuals.py
+git commit -m "refactor(residuals): extract ResidualsMixin shared by FitResult and MultiFitResult"
+```
+
+______________________________________________________________________
+
+### Task 3: `TitrationResults.residuals`
+
+**Files:**
+
+- Modify: `src/clophfit/prtecan/titration.py:19-25` (imports), `:413-437` (`TitrationResults` declaration)
+- Test: `tests/test_prtecan.py`
+
+**Interfaces:**
+
+- Consumes: `ResidualsMixin` from Task 2.
+
+- Produces: `TitrationResults.residuals` (`pd.DataFrame`) and `TitrationResults.residual_table(*, binding_function=None, robust=None, student_t_nu=None, outlier_threshold=3.0)`. Task 4 returns instances carrying these.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_prtecan.py`, inside the class that already provides the `tit` fixture (the one at line 1207, alongside `test_fit`):
+
+```python
+    def test_titration_results_residuals(self, tit: Titration) -> None:
+        """Plate results expose the canonical residual table."""
+        from clophfit.fitting.model_validation import RESIDUAL_TABLE_COLUMNS
+
+        ds = {k: tit.create_ds(k, label="2") for k in tit.fit_keys}
+        res = TitrationResults(tit.scheme, tit.fit_keys, fit_plate(ds, method="huber"))
+
+        table = res.residuals
+
+        assert list(table.columns) == RESIDUAL_TABLE_COLUMNS
+        assert not table.empty
+        # H02 fits on label 2; wells whose fit failed are skipped, not raised on.
+        assert "H02" in set(table["well"])
+        assert res.residuals is table  # cached
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_prtecan.py -k titration_results_residuals -v`
+Expected: FAIL with `AttributeError: 'TitrationResults' object has no attribute 'residuals'`.
+
+- [ ] **Step 3: Import the mixin and builder**
+
+In `src/clophfit/prtecan/titration.py`, extend the existing import block at lines 19-25 to:
+
+```python
+from clophfit.fitting.data_structures import (
+    DataArray,
+    Dataset,
+    FitResult,
+    NoiseModelParams,
+    PlateNoiseModel,
+    ResidualsMixin,
+)
+from clophfit.fitting.model_validation import residuals_from_fit_results
+```
+
+- [ ] **Step 4: Add the accessor**
+
+Change the `TitrationResults` declaration (currently line 414) to:
+
+```python
+class TitrationResults(ResidualsMixin):
+```
+
+and add this method to the class, directly after `__post_init__`:
+
+```python
+    def residual_table(
+        self,
+        *,
+        binding_function: Callable[..., object] | None = None,
+        robust: bool | None = None,
+        student_t_nu: float | None = None,
+        outlier_threshold: float = 3.0,
+    ) -> pd.DataFrame:
+        """Compute the canonical plate-wide residual table.
+
+        Parameters
+        ----------
+        binding_function : Callable[..., object] | None
+            Model evaluated for ``yhat``; defaults to ``binding_1site``.
+        robust : bool | None
+            Force the Student-t standardization of ``std_res``. ``None``
+            auto-detects, which for a classical plate fit means Normal.
+        student_t_nu : float | None
+            Student-t degrees of freedom (``None`` uses detected/default).
+        outlier_threshold : float
+            Threshold for the ``is_residual_outlier`` flag.
+
+        Returns
+        -------
+        pd.DataFrame
+            The canonical residual table (see :attr:`residuals`). Wells whose
+            fit failed carry no dataset or result and are skipped, so the table
+            may cover fewer wells than ``fit_keys``.
+        """
+        settings = self._resolve_residual_settings(
+            None,
+            binding_function=binding_function,
+            robust=robust,
+            student_t_nu=student_t_nu,
+        )
+        return residuals_from_fit_results(
+            self.results,
+            trace_id="",
+            binding_function=settings.binding_function,
+            robust=settings.robust,
+            student_t_nu=settings.student_t_nu,
+            outlier_threshold=outlier_threshold,
+            residual_likelihood=settings.residual_likelihood,
+        )
+```
+
+`Callable` is already available under `TYPE_CHECKING` (line 32), and the module has `from __future__ import annotations` (line 3), so the annotation resolves.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_prtecan.py -k titration_results_residuals -v`
+Expected: 1 passed.
+
+- [ ] **Step 6: Lint and typecheck**
+
+Run: `uv run ruff check src/clophfit/prtecan/titration.py && uv run mypy src/clophfit/prtecan/titration.py`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/clophfit/prtecan/titration.py tests/test_prtecan.py
+git commit -m "feat(prtecan): add residuals accessor to TitrationResults"
+```
+
+______________________________________________________________________
+
+### Task 4: `Titration.fit_plate`
+
+**Files:**
+
+- Modify: `src/clophfit/prtecan/titration.py` (imports; add `_fit_datasets` module-private helper and `Titration.fit_plate`)
+- Create: `tests/test_titration_fit_plate.py`
+
+**Interfaces:**
+
+- Consumes: `TitrationResults` (Task 3), `create_dataset_dict` (`titration.py:1067`).
+
+- Produces: `Titration.fit_plate(datasets=None, method="", *, label=None, **kwargs) -> TitrationResults` and module-private `_fit_datasets(datasets, method, **kwargs) -> dict[str, FitResult[Any]]`. Task 5 migrates callers onto `fit_plate`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_titration_fit_plate.py`:
+
+```python
+"""Tests for Titration.fit_plate dispatch and dataset construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from clophfit.fitting.data_structures import DataArray, Dataset, FitResult
+from clophfit.fitting.errors import InsufficientDataError
+from clophfit.prtecan.titration import Titration, TitrationResults
+
+data_tests = Path(__file__).parent / "Tecan"
+
+
+@dataclass
+class _Result:
+    residual: np.ndarray
+    success: bool = True
+
+
+@pytest.fixture(scope="module")
+def tit() -> Titration:
+    """A small pH titration; the fits themselves are monkeypatched away."""
+    return Titration.fromlistfile(data_tests / "L1" / "list.pH.csv", is_ph=True)
+
+
+def _dataset() -> Dataset:
+    x = np.array([6.0, 7.0, 8.0])
+    y = np.array([1.0, 2.0, 3.0])
+    return Dataset({"1": DataArray(x, y, y_errc=np.ones_like(y))}, is_ph=True)
+
+
+@pytest.mark.parametrize(
+    ("method", "target"),
+    [("", "lm"), ("huber", "huber"), ("odr", "odr"), ("mcmc", "mcmc")],
+)
+def test_fit_plate_routes_methods_and_preserves_well_keys(
+    monkeypatch: pytest.MonkeyPatch, tit: Titration, method: str, target: str
+) -> None:
+    """Plate fitting should dispatch each method to the intended backend."""
+    calls: list[tuple[str, str]] = []
+
+    def fake_glob(
+        ds: Dataset, *, method: str = "lm", **_kwargs: object
+    ) -> FitResult[Any]:
+        calls.append(("glob", method))
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    def fake_odr(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+        calls.append(("odr", "odr"))
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    def fake_mcmc(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+        calls.append(("mcmc", "mcmc"))
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_glob", fake_glob)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_odr", fake_odr)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_pymc", fake_mcmc)
+
+    results = tit.fit_plate({"A01": _dataset(), "A02": _dataset()}, method=method)
+
+    assert isinstance(results, TitrationResults)
+    assert set(results.results) == {"A01", "A02"}
+    assert all(fr.result is not None for fr in results.results.values())
+    assert calls == [(target if target in {"odr", "mcmc"} else "glob", target)] * 2
+
+
+@pytest.mark.parametrize("method", ["lm", "odr", "mcmc"])
+def test_fit_plate_turns_insufficient_data_into_empty_result(
+    monkeypatch: pytest.MonkeyPatch, tit: Titration, method: str
+) -> None:
+    """Per-well insufficient-data failures should not abort the whole plate."""
+
+    def fail(*_args: object, **_kwargs: object) -> FitResult[Any]:
+        msg = "too few points"
+        raise InsufficientDataError(msg)
+
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_glob", fail)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_odr", fail)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_pymc", fail)
+
+    results = tit.fit_plate({"A01": _dataset()}, method=method)
+
+    assert results["A01"].result is None
+
+
+def test_fit_plate_carries_plate_metadata(
+    monkeypatch: pytest.MonkeyPatch, tit: Titration
+) -> None:
+    """The returned container carries this titration's scheme and fit_keys."""
+
+    def fake_glob(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_glob", fake_glob)
+
+    results = tit.fit_plate({"A01": _dataset()})
+
+    assert results.scheme is tit.scheme
+    assert results.fit_keys == tit.fit_keys
+
+
+def test_fit_plate_builds_datasets_when_none_given(
+    monkeypatch: pytest.MonkeyPatch, tit: Titration
+) -> None:
+    """Omitting datasets delegates construction to create_dataset_dict."""
+    seen: list[str | None] = []
+    original = tit.create_dataset_dict
+
+    def spy(label: str | None = None) -> dict[str, Dataset]:
+        seen.append(label)
+        return original(label)
+
+    monkeypatch.setattr(tit, "create_dataset_dict", spy)
+    monkeypatch.setattr(
+        "clophfit.prtecan.titration.fit_binding_glob",
+        lambda ds, **_kw: FitResult(
+            result=_Result(np.zeros(len(next(iter(ds.values())).y))), dataset=ds
+        ),
+    )
+
+    tit.fit_plate(label="1")
+
+    assert seen == ["1"]
+
+
+def test_fit_plate_rejects_datasets_and_label_together(tit: Titration) -> None:
+    """datasets and label are alternative spellings of the same input."""
+    with pytest.raises(ValueError, match="not both"):
+        tit.fit_plate({"A01": _dataset()}, label="1")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_titration_fit_plate.py -v`
+Expected: FAIL with `AttributeError: 'Titration' object has no attribute 'fit_plate'`.
+
+- [ ] **Step 3: Import the fitting backends**
+
+In `src/clophfit/prtecan/titration.py`, add to the module-level imports (after the `clophfit.fitting.data_structures` block edited in Task 3):
+
+```python
+from clophfit.fitting.bayes import fit_binding_pymc
+from clophfit.fitting.core import fit_binding_glob
+from clophfit.fitting.errors import InsufficientDataError
+from clophfit.fitting.odr import fit_binding_odr
+```
+
+These are module-level, not lazy. Measured: `import clophfit.prtecan` already pulls PyMC via `titration.py:19` → `clophfit/fitting/__init__.py:7` → `bayes`, so this costs nothing new.
+
+- [ ] **Step 4: Add the dispatch helper**
+
+Add near the top of `src/clophfit/prtecan/titration.py`, after the `logger` assignment (line 49):
+
+```python
+def _fit_datasets(
+    datasets: dict[str, Dataset],
+    method: str,
+    **kwargs: typing.Any,  # noqa: ANN401
+) -> dict[str, FitResult[typing.Any]]:
+    """Fit each dataset, turning per-well failures into empty results.
+
+    Parameters
+    ----------
+    datasets : dict[str, Dataset]
+        Mapping of well keys to `Dataset` objects.
+    method : str
+        'lm', 'huber', 'odr', 'mcmc', or any method accepted by
+        :func:`clophfit.fitting.core.fit_binding_glob`.
+    **kwargs : typing.Any
+        Forwarded to the selected fitting function.
+
+    Returns
+    -------
+    dict[str, FitResult[typing.Any]]
+        One entry per input well; failed wells hold an empty `FitResult`.
+    """
+    fitter: Callable[..., FitResult[typing.Any]]
+    if method == "odr":
+        fitter, label = fit_binding_odr, "ODR fit"
+    elif method == "mcmc":
+        fitter, label = fit_binding_pymc, "MCMC fit"
+    else:
+        method = method or "lm"
+        fitter = functools.partial(fit_binding_glob, method=method)
+        label = "fit"
+
+    results: dict[str, FitResult[typing.Any]] = {}
+    for well, ds in datasets.items():
+        try:
+            results[well] = fitter(ds, **kwargs)
+        except InsufficientDataError:
+            logger.warning("Skip %s for well %s.", label, well)
+            results[well] = FitResult()
+    return results
+```
+
+Add `import functools` to the stdlib imports at the top of the module (after `import logging`, line 5).
+
+This collapses the original's three near-identical loops (`pipeline.py:255-278`) into one, and drops the stray `print(method)` (`pipeline.py:272`) — note `ruff` never caught it because `T20` is in the project's `ignore` list.
+
+- [ ] **Step 5: Add the method**
+
+Add to the `Titration` class, immediately after `create_dataset_dict` (which currently ends at line 1092):
+
+```python
+    def fit_plate(
+        self,
+        datasets: dict[str, Dataset] | None = None,
+        method: str = "",
+        *,
+        label: str | None = None,
+        **kwargs: typing.Any,  # noqa: ANN401
+    ) -> TitrationResults:
+        """Run a single-pass fit on an entire plate of datasets.
+
+        Parameters
+        ----------
+        datasets : dict[str, Dataset] | None
+            Mapping of well keys (e.g. 'A01') to `Dataset` objects. When
+            ``None``, datasets are built with :meth:`create_dataset_dict`,
+            which also applies outlier masking when ``params.mask_outliers``
+            is set.
+        method : str
+            The fitting method: 'lm' (default), 'huber', 'odr', or 'mcmc'.
+            Other methods supported by
+            :func:`clophfit.fitting.core.fit_binding_glob` may also be used.
+        label : str | None
+            Build per-label datasets for this label instead of global ones.
+            Only valid when *datasets* is ``None``.
+        **kwargs : typing.Any
+            Additional keyword arguments passed to the fitting function.
+
+        Returns
+        -------
+        TitrationResults
+            Plate results carrying this titration's ``scheme`` and ``fit_keys``.
+
+        Raises
+        ------
+        ValueError
+            If both *datasets* and *label* are given.
+        """
+        if datasets is not None and label is not None:
+            msg = "Pass either `datasets` or `label`, not both."
+            raise ValueError(msg)
+        if datasets is None:
+            datasets = self.create_dataset_dict(label)
+        results = _fit_datasets(datasets, method, **kwargs)
+        return TitrationResults(self.scheme, self.fit_keys, results)
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_titration_fit_plate.py -v`
+Expected: 10 passed — 4 routing (parametrized) + 3 insufficient-data (parametrized) + metadata + builds-datasets + rejects-both.
+
+- [ ] **Step 7: Lint and typecheck**
+
+Run: `uv run ruff check src/clophfit/prtecan/titration.py tests/test_titration_fit_plate.py && uv run mypy src/clophfit/prtecan/titration.py`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/clophfit/prtecan/titration.py tests/test_titration_fit_plate.py
+git commit -m "feat(prtecan): add Titration.fit_plate returning TitrationResults"
+```
+
+______________________________________________________________________
+
+### Task 5: Migrate `export.py` and `test_prtecan.py`
+
+Collapses the three fit-then-wrap pairs. Each call keeps passing its explicitly-built dataset dict, so behaviour is unchanged — those dicts (`export.py:169,176`) deliberately skip the `mask_outliers` step that `create_dataset_dict` applies.
+
+**Files:**
+
+- Modify: `src/clophfit/prtecan/export.py:19` (import), `:178-185`, `:194-201`, `:203-210`
+- Modify: `tests/test_prtecan.py:1286-1310`
+
+**Interfaces:**
+
+- Consumes: `Titration.fit_plate` (Task 4).
+
+- Produces: nothing new.
+
+- [ ] **Step 1: Migrate the three call sites**
+
+In `src/clophfit/prtecan/export.py`, replace the per-label block (currently 178-185):
+
+```python
+            export_list.append(
+                titration.fit_plate(
+                    ds_single,
+                    method=titration.params.fit_method,
+                    remove_outliers=titration.params.outlier,
+                )
+            )
+```
+
+Replace the global block (currently 194-201):
+
+```python
+    global_res = titration.fit_plate(
+        datasets,
+        method=method,
+        reweight=reweight,
+        remove_outliers=titration.params.outlier,
+    )
+    export_list.append(global_res)
+```
+
+Replace the ODR block (currently 203-210):
+
+```python
+    odr_res = titration.fit_plate(
+        datasets,
+        method="odr",
+        remove_outliers=titration.params.outlier,
+        reweight=reweight,
+    )
+    export_list.append(odr_res)
+```
+
+Delete the now-unused import on line 19:
+
+```python
+from clophfit.fitting.pipeline import fit_plate
+```
+
+Leave `TitrationResults` imported (line 25) — `export_bad_wells` still annotates with it.
+
+- [ ] **Step 2: Migrate the prtecan fit test**
+
+In `tests/test_prtecan.py`, rewrite `test_fit` (currently 1286-1310) to use the method. `TitrationResults.__getitem__` means the `res[...]` accesses are unchanged:
+
+```python
+    def test_fit(self, tit: Titration) -> None:
+        """It fits each label separately."""
+        # Test Label 1 for H02 (should be skipped because of OVER value or insufficient points)
+        ds1 = {k: tit.create_ds(k, label="1") for k in tit.fit_keys}
+        res1 = tit.fit_plate(ds1, method="huber")
+        assert not res1["H02"].is_valid()
+
+        # Test Label 2 for H02
+        ds2 = {k: tit.create_ds(k, label="2") for k in tit.fit_keys}
+        res2 = tit.fit_plate(ds2, method="huber")
+        assert res2["H02"].is_valid()
+
+        # Check 'K' and std error for 'H02' in the second fit result
+        assert res2["H02"].result is not None
+        k_h02 = res2["H02"].result.params["K"]
+        assert k_h02.value == pytest.approx(7.899, abs=1e-3)
+        assert k_h02.stderr == pytest.approx(0.026, abs=1e-3)
+
+        # Check 'K' and std error for 'H02' in global fit
+        ds_global = {k: tit.create_global_ds(k) for k in tit.fit_keys}
+        res_global = tit.fit_plate(ds_global, method="huber")
+        assert res_global["H02"].result is not None
+        k_h02_glob = res_global["H02"].result.params["K"]
+        assert k_h02_glob.value == pytest.approx(7.899, abs=1e-3)
+        assert k_h02_glob.stderr == pytest.approx(0.026, abs=1e-3)
+```
+
+Then update the Task 3 test you added (`test_titration_results_residuals`) to build via the method:
+
+```python
+        res = tit.fit_plate({k: tit.create_ds(k, label="2") for k in tit.fit_keys}, method="huber")
+```
+
+Delete the now-unused `from clophfit.fitting.pipeline import fit_plate` import at `tests/test_prtecan.py:19`.
+
+- [ ] **Step 2b: Run to verify**
+
+Run: `uv run pytest tests/test_prtecan.py -k "fit or residuals" -q`
+Expected: all pass, with the same `K` values (7.899 ± 0.026) as before — proving the move preserved fitting behaviour.
+
+- [ ] **Step 3: Run the CLI/export suites**
+
+Run: `uv run pytest tests/test_cli.py tests/test_prtecan.py -q`
+Expected: all pass. `export_fit` is the main consumer of the migrated code.
+
+- [ ] **Step 4: Lint and typecheck**
+
+Run: `uv run ruff check src/clophfit/prtecan/export.py tests/test_prtecan.py && uv run mypy src/clophfit/prtecan/export.py`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/clophfit/prtecan/export.py tests/test_prtecan.py
+git commit -m "refactor(prtecan): use Titration.fit_plate in export and tests"
+```
+
+______________________________________________________________________
+
+### Task 6: Migrate the tutorial notebook
+
+Must land **before** Task 7. The docs build executes this notebook with `nb_execution_allow_errors = False`, so a dangling `pipeline.fit_plate` import would fail CI's `docs_build` job.
+
+**Files:**
+
+- Modify: `docs/tutorials/prtecan.ipynb` — the fit cell, the MCMC cell, the residuals cell, and the `cl_an` cell
+
+Locate cells by **content**, not line number: `docs/tutorials/.virtual_documents/prtecan.ipynb` is a stale mirror (it still shows the `collect_multi_residuals` call removed in `e906ec9`), so its line numbers do not match the real notebook.
+
+Verified facts about this notebook: `tit` and `cl_an` are both `Titration` instances; `ds_dict1`, `ds_dict2`, `ds_dict_glob`, and `res1`…`res_odr` are used **only** to build `tr1`…`tr_odr`; but `tr1`, `tr2`, `tr_glob`, and `tr_odr` are used throughout later cells (well comparison, `.dataframe`, `.figure`, the residuals cell) and **must keep their names**.
+
+**Interfaces:**
+
+- Consumes: `Titration.fit_plate` (Task 4).
+
+- Produces: nothing.
+
+- [ ] **Step 1: Collapse the main fit cell**
+
+Replace the whole cell that currently reads:
+
+```python
+from clophfit.fitting.pipeline import fit_plate
+from clophfit.prtecan import TitrationResults
+
+# Create dataset dicts
+ds_dict1 = tit.create_dataset_dict("1")
+ds_dict2 = tit.create_dataset_dict("2")
+ds_dict_glob = tit.create_dataset_dict()
+
+# Compute fits
+res1 = fit_plate(ds_dict1, method="lm")
+res2 = fit_plate(ds_dict2, method="lm")
+res_glob = fit_plate(ds_dict_glob, method="lm")
+res_odr = fit_plate(ds_dict_glob, method="odr")
+
+# Create TitrationResults wrappers for dataframe access
+tr1 = TitrationResults(tit.scheme, tit.fit_keys, res1)
+tr2 = TitrationResults(tit.scheme, tit.fit_keys, res2)
+tr_glob = TitrationResults(tit.scheme, tit.fit_keys, res_glob)
+tr_odr = TitrationResults(tit.scheme, tit.fit_keys, res_odr)
+```
+
+with:
+
+```python
+# Fit each label and the global dataset; plate metadata comes from the titration
+tr1 = tit.fit_plate(label="1", method="lm")
+tr2 = tit.fit_plate(label="2", method="lm")
+tr_glob = tit.fit_plate(method="lm")
+tr_odr = tit.fit_plate(method="odr")
+```
+
+This is behaviour-preserving: `fit_plate(label="1")` builds its datasets with the same `tit.create_dataset_dict("1")` the cell called explicitly.
+
+- [ ] **Step 2: Update the MCMC cell**
+
+`ds_mcmc` is a hand-built single-well dict, so it stays and is passed explicitly. Replace:
+
+```python
+res_mcmc = fit_plate(ds_mcmc, method="mcmc")
+```
+
+with:
+
+```python
+res_mcmc = tit.fit_plate(ds_mcmc, method="mcmc")
+```
+
+- [ ] **Step 3: Update the `cl_an` cell**
+
+Replace:
+
+```python
+ds_glob_cl = cl_an.create_dataset_dict()
+tr_glob_cl = prtecan.TitrationResults(
+    cl_an.scheme, cl_an.fit_keys, fit_plate(ds_glob_cl, method="lm")
+)
+```
+
+with:
+
+```python
+tr_glob_cl = cl_an.fit_plate(method="lm")
+```
+
+- [ ] **Step 4: Simplify the residuals cell**
+
+Replace:
+
+```python
+all_res = residuals_from_fit_results(
+    {w: tr_glob[w] for w in tit.fit_keys},
+    trace_id="",
+    binding_function=binding_1site,
+)
+diag = ResidualDiagnostics(all_res)
+```
+
+with:
+
+```python
+diag = ResidualDiagnostics(tr_glob.residuals)
+```
+
+This cell is the whole point of the feature — it should demonstrate the accessor. Adjust that cell's imports so only `ResidualDiagnostics` remains, dropping `residuals_from_fit_results` and `binding_1site` if no other cell uses them.
+
+- [ ] **Step 5: Prune dead imports**
+
+`from clophfit.fitting.pipeline import fit_plate` is gone. `TitrationResults` / `prtecan.TitrationResults` may now be unused — Step 6's ruff run reports it as `F401`; delete only what ruff flags.
+
+- [ ] **Step 6: Verify the notebook executes**
+
+Run: `uv run jupyter nbconvert --to notebook --execute --stdout docs/tutorials/prtecan.ipynb > /dev/null`
+Expected: completes without error. This is what CI's `docs_build` does; `nb_execution_allow_errors = False` means any traceback fails the job.
+
+- [ ] **Step 7: Lint the notebook**
+
+Run: `uv run ruff check docs/tutorials/prtecan.ipynb`
+Expected: `All checks passed!` (ruff lints notebooks here via `extend-include`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/tutorials/prtecan.ipynb
+git commit -m "docs(tutorial): use Titration.fit_plate and TitrationResults.residuals"
+```
+
+______________________________________________________________________
+
+### Task 7: Delete `pipeline.fit_plate` and prune
+
+**Files:**
+
+- Modify: `src/clophfit/fitting/pipeline.py:1-26` (imports), delete `:230-280` (`fit_plate`)
+- Modify: `tests/test_pipeline.py` — delete the two `fit_plate` tests (`:57-116`) and the now-unused helpers
+
+**Interfaces:**
+
+- Consumes: nothing.
+
+- Produces: nothing. `pipeline` now exports only `calibrate_noise_robust` and `fgls_plate_fit`.
+
+- [ ] **Step 1: Confirm no consumers remain**
+
+Run: `grep -rn "pipeline import fit_plate\|pipeline.fit_plate" src/ tests/ docs/tutorials/ --include='*.py' --include='*.ipynb'`
+Expected: no output. If anything matches (other than `prtecan_devel.ipynb`, which is out of scope), migrate it before continuing.
+
+- [ ] **Step 2: Delete the function**
+
+Delete `src/clophfit/fitting/pipeline.py:230-280` in full — the whole `fit_plate` definition, including the stray `print(method)` at line 272.
+
+- [ ] **Step 3: Prune newly-unused imports**
+
+Run: `uv run ruff check src/clophfit/fitting/pipeline.py`
+
+Ruff's `F401` reports which of `fit_binding_pymc` (line 8), `fit_binding_glob` (9), `fit_binding_odr` (19), and `InsufficientDataError` (16) are now unused. Delete exactly those it flags — `fgls_plate_fit` still uses some of them, so do not guess. Then re-run until clean.
+
+- [ ] **Step 4: Delete the migrated tests**
+
+In `tests/test_pipeline.py`, delete `test_fit_plate_routes_methods_and_preserves_well_keys` (with its `@pytest.mark.parametrize`, lines 57-96) and `test_fit_plate_turns_insufficient_data_into_empty_result` (99-116). They now live in `tests/test_titration_fit_plate.py`.
+
+Keep `_dataset`, `_Result`, and the `InsufficientDataError` import only if the remaining FGLS tests still reference them — run ruff to confirm and delete whatever it flags as unused.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run pytest tests/ -q -m "not slow"`
+Expected: all pass. This is the first point where every consumer must be migrated, so a failure here means a missed call site.
+
+- [ ] **Step 6: Lint and typecheck the whole package**
+
+Run: `uv run ruff check src/ tests/ && uv run mypy src/clophfit`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/clophfit/fitting/pipeline.py tests/test_pipeline.py
+git commit -m "refactor(pipeline): drop fit_plate, leaving only FGLS orchestration"
+```
+
+______________________________________________________________________
+
+### Task 8: Hoist the `titration.py` lazy import
+
+Independent cleanup. `clophfit.fitting.utils` is already imported at module level on line 28, so this laziness buys nothing.
+
+**Files:**
+
+- Modify: `src/clophfit/prtecan/titration.py:28` (import), `:692-696` (delete lazy import)
+
+**Interfaces:**
+
+- Consumes: nothing.
+
+- Produces: nothing.
+
+- [ ] **Step 1: Extend the module-level import**
+
+In `src/clophfit/prtecan/titration.py`, change line 28 to:
+
+```python
+from clophfit.fitting.utils import (
+    apply_outlier_mask,
+    flag_trend_outliers,
+    roughness,
+    smoothness,
+)
+```
+
+- [ ] **Step 2: Delete the lazy import**
+
+Delete these lines from the method body (currently 692-696):
+
+```python
+        from clophfit.fitting.utils import (  # noqa: PLC0415
+            flag_trend_outliers,
+            roughness,
+            smoothness,
+        )
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `uv run pytest tests/test_prtecan.py tests/test_imports.py -q`
+Expected: all pass.
+
+- [ ] **Step 4: Lint and typecheck**
+
+Run: `uv run ruff check src/clophfit/prtecan/titration.py && uv run mypy src/clophfit/prtecan/titration.py`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/clophfit/prtecan/titration.py
+git commit -m "refactor(imports): hoist titration outlier-helper import to module level"
+```
+
+______________________________________________________________________
+
+## Final verification
+
+- [ ] Run the full suite including slow tests: `uv run pytest tests/ -q`
+- [ ] Build the docs the way CI does: `NB_EXECUTION_MODE=cache uv run make docs`
+- [ ] Confirm the feature works end-to-end in a REPL:
+
+```python
+from clophfit.prtecan.titration import Titration
+
+tit = Titration.fromlistfile("tests/Tecan/140220/list.pH.csv", is_ph=True)
+res_glob = tit.fit_plate(method="huber")
+print(res_glob.residuals.head())   # the accessor this plan exists to add
+print(res_glob.plot_k())           # plate metadata still available
+```
+
+## Known follow-ups (out of scope)
+
+- `prtecan_devel.ipynb` has six `fit_plate` calls and uncommitted user changes; the user migrates it.
+- `titration.py` is ~1200 lines after this work and remains a split candidate.
+- FGLS (`fgls_plate_fit`, `calibrate_noise_robust`) has no production callers — only tests and the devel notebook.

--- a/docs/superpowers/specs/2026-07-17-plate-fit-residuals-design.md
+++ b/docs/superpowers/specs/2026-07-17-plate-fit-residuals-design.md
@@ -132,11 +132,35 @@ The mixin is applied to `FitResult`, `MultiFitResult`, and `TitrationResults`.
 
 `TitrationResults` (`prtecan/titration.py:414`) already carries
 `results: dict[str, FitResult]`, `scheme`, `fit_keys`, `dataframe`, `n_sd`, and
-`plot_k` (line 522). It gains `residuals` from the mixin and implements its own
-`residual_table()` in the §2 shape: resolve settings via
-`_resolve_residual_settings(trace=None, ...)` — classical plate fits have no
-trace, so this resolves to Normal standardization — then delegate to
-`residuals_from_fit_results(self.results, trace_id="", ...)`.
+`plot_k` (line 522). It gains `residuals` from the mixin, but **not** a
+plate-wide call into `_resolve_residual_settings`/`residuals_from_fit_results`.
+
+A plate can hold PyMC fits (`fit_plate(..., method="mcmc")` dispatches
+per-well to `fit_binding_pymc`), and each well's trace lives in that well's
+own `FitResult.mini` — there is no single plate-wide trace to resolve
+against. A single `trace=` kwarg on the plate's `residual_table` cannot
+represent 96 independent traces. So `TitrationResults.residual_table()`
+instead delegates to each well: for every `(well, fr)` in `self.results`
+where `fr.dataset is not None and fr.result is not None`, it calls
+`fr.residual_table(well=well, binding_function=..., robust=..., student_t_nu=..., outlier_threshold=...)`, forwarding its own parameters through unchanged, and
+concatenates the per-well frames with `pd.concat(..., ignore_index=True)`. Each
+`FitResult.residual_table` already resolves its own trace from `self.mini`
+(§2), so a classical well (`mini` is an lmfit `Minimizer` or ODR output)
+correctly resolves to Normal standardization, and an MCMC well (`mini` is an
+`xr.DataTree`) correctly resolves to Student-t/robust standardization from
+its own posterior — fixing the mislabeled `residual_likelihood` and all-NaN
+`p_outlier` that a single hard-coded `trace=None` produced for MCMC plates.
+When no wells survive, an empty `pd.DataFrame(columns=RESIDUAL_TABLE_COLUMNS)`
+is returned so the schema stays stable.
+
+For a classical plate (`lm`/`huber`/`odr`), this is provably identical to the
+old single-call implementation: with no trace, each well's rows depend only
+on that well's own dataset and params, so per-well resolution and one
+plate-wide call over the same wells produce the same rows. Verified
+empirically against `tests/Tecan/140220/list.pH.csv` fitted with
+`method="huber"`: before and after tables are identical via
+`pandas.testing.assert_frame_equal` (shape `(1337, 17)`, 96 wells, including
+row order — the dict-iteration order is preserved either way).
 
 **Failed wells are skipped, not raised on.** `residuals_from_fit_results` already
 drops entries where `fr.dataset is None or fr.result is None`
@@ -281,3 +305,25 @@ synthetic unit tests.
 - Splitting `titration.py`.
 - Method-aware robust standardization for classical fits.
 - Any change to `RESIDUAL_TABLE_COLUMNS` or the residual builders themselves.
+
+### Follow-ups (future design context, not implemented here)
+
+`Titration.fit_plate` is ultimately intended to cover more plate-fitting
+strategies than it does today. Recorded here as roadmap context only:
+
+- **(a) Per-well PyMC.** Already supported today via `method="mcmc"`, and as
+  of this fix its residuals resolve correctly per well (see §3 above).
+- **(b) `pymc_multi`.** All wells fitted together in one hierarchical model.
+  This returns `MultiFitResult`, not `TitrationResults` — `MultiFitResult`
+  already has its own `residuals` via `residuals_from_multifit` over its
+  single shared trace (§4). Because it is a trace proxy over one posterior
+  rather than a plate of independent per-well fits, it does not fit
+  `Titration.fit_plate`'s current `-> TitrationResults` return type, and
+  reconciling the two return shapes is unresolved design work, not scoped
+  here.
+- **(c) FGLS.** Per-well huber fit, derive a noise model from the overall
+  residuals, apply it to the dataset dict — with outlier removal still to be
+  added — then rerun a final fit. This exists today as `fgls_plate_fit` in
+  `clophfit/fitting/pipeline.py`, orchestrated separately from
+  `Titration.fit_plate`; folding it into `fit_plate` (or vice versa) is
+  future work.

--- a/docs/superpowers/specs/2026-07-17-plate-fit-residuals-design.md
+++ b/docs/superpowers/specs/2026-07-17-plate-fit-residuals-design.md
@@ -1,0 +1,283 @@
+# Plate-level fit results with unified residual access
+
+- **Date:** 2026-07-17
+- **Status:** approved, pending implementation plan
+- **Scope:** `clophfit.fitting.pipeline`, `clophfit.fitting.data_structures`, `clophfit.prtecan.titration`, `clophfit.prtecan.export`
+
+## Problem
+
+`fit_plate` returns a bare `dict[str, FitResult]`, so a plate fit has no residual
+accessor:
+
+```python
+res_glob = pipeline.fit_plate(ds_dict, "huber")
+res_glob.residuals          # AttributeError
+```
+
+Callers must instead reach for the builder by hand, restating what the fit
+already knows:
+
+```python
+all_res = residuals_from_fit_results(res_glob, trace_id="", binding_function=binding_1site)
+```
+
+This is inconsistent with the rest of the package, where `FitResult.residuals`
+(`data_structures.py:525`) and `MultiFitResult.residuals` (`data_structures.py:613`)
+both exist as cached properties over the same canonical schema.
+
+Four further problems cluster around the same code:
+
+1. **Repeated fit-then-wrap.** Every production call site of `fit_plate` immediately
+   wraps the result with plate metadata it already has —
+   `export.py:178→184`, `194→200`, `203→209`:
+
+   ```python
+   global_fits = fit_plate(datasets, method=method, ...)
+   global_res = TitrationResults(titration.scheme, titration.fit_keys, global_fits)
+   ```
+
+1. **Duplicated residual-settings logic.** `FitResult.residual_table`
+   (`data_structures.py:537-591`) and `MultiFitResult.residual_table`
+   (`data_structures.py:624-674`) are near-identical: the same
+   `robust_likelihood_from_trace` → `robust_settings_from_trace` → `STUDENT_T_NU`
+   fallback, differing only in the trace source and the terminal builder call.
+   Adding a third plate-level accessor would be a third copy.
+
+1. **`fit_plate` lives in the wrong module.** `pipeline.py` is documented as
+   "Pipeline orchestrators for fitting multistage workflows (e.g., FGLS)". That
+   describes `fgls_plate_fit` / `calibrate_noise_robust`, but `fit_plate` is a
+   single-pass dispatch loop, not a multistage workflow.
+
+1. **Stray debug output.** `pipeline.py:272` contains a bare `print(method)` that
+   fires on every `lm`/`huber`/`irls` plate fit, including from `export.py`.
+
+## Design
+
+### 1. `Titration.fit_plate()` replaces `pipeline.fit_plate()`
+
+`fit_plate` moves to `clophfit.prtecan.titration` as a method on `Titration`, and
+returns `TitrationResults` directly.
+
+```python
+def fit_plate(
+    self,
+    datasets: dict[str, Dataset] | None = None,
+    method: str = "",
+    *,
+    label: str | None = None,
+    **kwargs: typing.Any,
+) -> TitrationResults:
+```
+
+**Rationale.** Both dataset dicts in `export.py` are pure functions of the
+titration — `{k: titration.create_global_ds(k) for k in titration.fit_keys}`
+(line 169) and `{k: titration.create_ds(k, label=label) for k in titration.fit_keys}`
+(line 176) — so a method on `Titration` already holds everything it needs.
+`Titration` owns `fit_keys` (`titration.py:644`), `create_ds` (1055), and
+`create_global_ds` (1061); `fit_plate` joins that family. `TitrationResults` is
+defined at line 414, before `Titration` at 602, so the return annotation needs no
+forward reference. `titration.py` already imports `clophfit.fitting` at module
+level (lines 19-28), so no dependency boundary is crossed: `prtecan → fitting` is
+the established direction, and `fitting → prtecan` exists only under
+`TYPE_CHECKING` (`bayes.py:55-59`).
+
+**Semantics.**
+
+- `datasets` stays positional so existing calls survive verbatim:
+  `tit.fit_plate(ds_dict, "huber")`.
+- `datasets=None` → build via the **existing** `self.create_dataset_dict(label)`
+  (`titration.py:1067`), which already switches on `label` (global when `None`,
+  per-label otherwise) and additionally applies `apply_outlier_mask` when
+  `self.params.mask_outliers` is set. Reusing it keeps this DRY and avoids
+  re-deriving the dict comprehension.
+- Note the resulting asymmetry, which is intentional: `export.py` passes its own
+  explicitly-built dicts (`export.py:169,176`) that skip `mask_outliers`, so its
+  behaviour is unchanged by this refactor; only the new `datasets=None`
+  convenience path picks masking up.
+- Passing both `datasets` and `label` raises `ValueError`. The two are
+  alternative ways to specify the same input; silently preferring one would be
+  implicit behaviour.
+- Returns `TitrationResults(self.scheme, self.fit_keys, results)`.
+- Dispatch, the `InsufficientDataError` → empty `FitResult()` handling, and
+  `**kwargs` pass-through (`remove_outliers`, `reweight`, …) are carried over
+  from the current implementation unchanged.
+
+Explicit `datasets` must remain supported: `prtecan_devel.ipynb` mutates datasets
+before fitting (`ds['1'].mask[-1] = False`, `ds["1"].y_err /= ...`), so building
+them internally cannot be mandatory.
+
+`fit_binding_pymc` is imported at **module level**, not lazily — see §5.
+
+### 2. `ResidualsMixin` in `data_structures.py`
+
+A mixin holds the two things that are genuinely shared:
+
+- `residuals` — `cached_property` returning `self.residual_table()`, with the
+  canonical docstring.
+- `_resolve_residual_settings(trace, *, binding_function, robust, student_t_nu)` —
+  the auto-detection currently duplicated in both `residual_table` bodies,
+  returning a `NamedTuple` of `(binding_function, robust, student_t_nu, residual_likelihood)`.
+
+Each class keeps its **own** `residual_table` with its own precise signature,
+reduced to roughly six lines: resolve settings, then call its builder. This is
+deliberate — `FitResult.residual_table` takes a `well: str = ""` parameter that
+the others do not, and it is exercised by
+`test_model_validation_smoke.py:839,860,888`. Pushing a single shared
+`residual_table` signature onto all three would either drop `well` or force
+loosely-typed `**kwargs`, both worse than a six-line method per class.
+
+The mixin is applied to `FitResult`, `MultiFitResult`, and `TitrationResults`.
+
+### 3. `TitrationResults` gains `.residuals`
+
+`TitrationResults` (`prtecan/titration.py:414`) already carries
+`results: dict[str, FitResult]`, `scheme`, `fit_keys`, `dataframe`, `n_sd`, and
+`plot_k` (line 522). It gains `residuals` from the mixin and implements its own
+`residual_table()` in the §2 shape: resolve settings via
+`_resolve_residual_settings(trace=None, ...)` — classical plate fits have no
+trace, so this resolves to Normal standardization — then delegate to
+`residuals_from_fit_results(self.results, trace_id="", ...)`.
+
+**Failed wells are skipped, not raised on.** `residuals_from_fit_results` already
+drops entries where `fr.dataset is None or fr.result is None`
+(`model_validation.py:1779-1780`), which is exactly the empty `FitResult()`
+produced by the `InsufficientDataError` path. A plate with failed wells therefore
+yields a quietly shorter table; this matches existing behaviour and is documented
+in the property docstring rather than changed.
+
+After this, `fr.residuals`, `res_glob.residuals`, `multi.residuals`, and
+`tit_res.residuals` all return the same `RESIDUAL_TABLE_COLUMNS` schema and feed
+`ResidualDiagnostics`, `residual_statistics`, and the `plot_residual_vs_*`
+helpers interchangeably.
+
+### 4. `MultiFitResult` stays as-is
+
+It is **not** merged into `TitrationResults`. It is a trace proxy, not a plate
+container: `__getattr__` delegates to `self.trace`, and `plotting.py` treats it
+polymorphically with the raw trace across six signatures
+(`trace: xr.DataTree | MultiFitResult`) plus an `isinstance` branch at line 1145.
+Its per-well results are reconstructed from one shared hierarchical posterior —
+a different object from a plate of independent fits. Merging would drag a PyMC
+trace and trace-delegation into the plate-metadata class.
+
+What is unified is the **schema and the accessor**, not the type.
+
+### 5. Imports become module-level
+
+Every lazy import in the affected code is removed, and the one originally planned
+for this work is not introduced. Each was verified unnecessary rather than
+assumed so.
+
+- **`data_structures.py:568-569`** (`from clophfit.fitting import model_validation`,
+  `from clophfit.fitting.models import binding_1site`). These are lazy because
+  they use the **package-attribute form**, which requires `fitting/__init__.py`
+  to have finished binding the attribute — and `__init__` eagerly imports `bayes`
+  (line 7) → … → `data_structures`, so at module level that form would read off a
+  partially-initialized package. The **submodule-direct form**
+  (`from clophfit.fitting.model_validation import residuals_from_fit_results`)
+  sidesteps this by importing the submodule instead of an attribute of the parent.
+  Safe because the graph is acyclic: `model_validation` → `residuals` (which
+  imports nothing from `clophfit`), `models` → `clophfit_types`, and
+  `model_validation` never references `data_structures`.
+  *Verified empirically*: patched to module-level, both `import clophfit.fitting`
+  (worst case, through the eager `__init__`) and a cold submodule-first import
+  succeeded; then reverted.
+
+- **`titration.py:692`** (`flag_trend_outliers`, `roughness`, `smoothness` from
+  `clophfit.fitting.utils`). Redundant: that module is already imported at
+  **line 28** (`from clophfit.fitting.utils import apply_outlier_mask`). Folds
+  into line 28's import list.
+
+- **The planned lazy `fit_binding_pymc` import is not needed.** *Measured*:
+  `import clophfit.prtecan` already takes 0.79 s and already has `pymc` in
+  `sys.modules`, because `titration.py:19` → `clophfit.fitting.__init__` →
+  `bayes` (line 7) → PyMC. A module-level import in `titration.py` therefore
+  costs nothing new.
+
+Their `# noqa: PLC0415` suppressions are dropped with them.
+
+### 6. `pipeline.py` keeps FGLS only
+
+With `fit_plate` gone, `pipeline.py` contains `fgls_plate_fit`,
+`calibrate_noise_robust`, `_noise_params_converged`, and
+`_plate_noise_model_from_nnls` — which is precisely what its docstring already
+claims. The stray `print(method)` (line 272) is deleted along with the function
+that hosts it. Module-level imports that become unused after the move
+(`fit_binding_pymc`, `fit_binding_odr`, `fit_binding_glob`,
+`InsufficientDataError`) are pruned if no FGLS code path uses them.
+
+FGLS itself is unchanged. Its only callers are the test suite and
+`prtecan_devel.ipynb`; it is experimental, not dead, and out of scope here.
+
+## Migration
+
+| Call site       | Before                                                             | After                                              |
+| --------------- | ------------------------------------------------------------------ | -------------------------------------------------- |
+| `export.py:178` | `fit_plate(ds_single, ...)` + `TitrationResults(...)`              | `titration.fit_plate(ds_single, ...)`              |
+| `export.py:194` | `fit_plate(datasets, ...)` + `TitrationResults(...)`               | `titration.fit_plate(datasets, ...)`               |
+| `export.py:203` | `fit_plate(datasets, method="odr", ...)` + `TitrationResults(...)` | `titration.fit_plate(datasets, method="odr", ...)` |
+
+`export.py` drops its `from clophfit.fitting.pipeline import fit_plate` import
+(line 19). The three `export_list.append(...)` wraps collapse to single calls.
+
+`tests/test_pipeline.py` currently monkeypatches
+`clophfit.fitting.pipeline.fit_binding_glob` / `fit_binding_odr` /
+`fit_binding_pymc` (lines 88-90, 110-112). The `fit_plate` tests
+(`test_fit_plate_routes_methods_and_preserves_well_keys`,
+`test_fit_plate_turns_insufficient_data_into_empty_result`) move to the prtecan
+test module and repatch against `clophfit.prtecan.titration`. The FGLS tests stay.
+`tests/test_prtecan.py:1290,1295,1306` switch to the method form.
+
+Notebooks (`docs/tutorials/prtecan.ipynb:263-275,332`, `prtecan_devel.ipynb`) drop
+the `pipeline` import and call `tit.fit_plate(...)`.
+
+**No deprecation shim.** The plate-fit entry point becomes prtecan-only; there is
+no generic "fit a dict of datasets" API left in `fitting/`. This is accepted:
+every production caller is in `prtecan`, and the only metadata-free callers are
+synthetic unit tests.
+
+## Testing
+
+- `Titration.fit_plate` returns `TitrationResults` with `scheme`/`fit_keys`
+  populated from the titration.
+- Dataset construction: `datasets=None` builds global; `label="1"` builds
+  per-label; both together raise `ValueError`.
+- Method routing (`lm`, `huber`, `odr`, `mcmc`) and well-key preservation —
+  ported from `test_pipeline.py:66-98`.
+- `InsufficientDataError` still yields an empty `FitResult()` for that well —
+  ported from `test_pipeline.py:100-116`.
+- `TitrationResults.residuals` returns `RESIDUAL_TABLE_COLUMNS`, populates `well`
+  per row, and skips failed wells.
+- Parity: `TitrationResults.residuals` and `MultiFitResult.residuals` agree on
+  columns and dtypes.
+- `FitResult.residual_table(well=...)` keeps working after the mixin refactor
+  (`test_model_validation_smoke.py:839,860,888` must pass unchanged).
+- An import test asserting no lazy-import regression: `import clophfit.prtecan`
+  and `import clophfit.fitting` both succeed cold.
+
+## Risks and limitations
+
+- **`cached_property` staleness.** `TitrationResults.residuals` caches on first
+  access; mutating `results` afterwards yields a stale table. This already applies
+  to `FitResult.residuals` and `MultiFitResult.residuals`, and `TitrationResults`
+  already hand-rolls a similar cache for `dataframe` (with an index check). Accepted
+  as consistent with existing behaviour; `residual_table()` remains the uncached
+  escape hatch.
+- **`titration.py` growth.** Currently ~1160 lines; this adds ~50. Acceptable for
+  now, but the file is a future split candidate (`Titration`, `TitrationResults`,
+  and `Buffer`/`BufferFit` are separable).
+- **Robustness auto-detection is PyMC-only.** `robust_settings_from_trace` infers
+  Student-t standardization from a trace; classical fits (`lm`, `huber`, `odr`)
+  have no trace and correctly resolve to `robust=False`, i.e. Normal
+  standardization. This is intended — `robust` here means specifically "apply the
+  Student-t probability-integral transform", which is valid only for a Student-t
+  likelihood, not for the Huber M-estimator's least-favorable density. Behaviour
+  is unchanged by this spec; noted because "huber ⇒ robust=True" is an inviting
+  and wrong inference.
+
+## Out of scope
+
+- FGLS behaviour changes.
+- Splitting `titration.py`.
+- Method-aware robust standardization for classical fits.
+- Any change to `RESIDUAL_TABLE_COLUMNS` or the residual builders themselves.

--- a/docs/tutorials/prtecan.ipynb
+++ b/docs/tutorials/prtecan.ipynb
@@ -259,7 +259,24 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Fit each label and the global dataset; plate metadata comes from the titration\ntr1 = tit.fit_plate(label=\"1\", method=\"lm\")\ntr2 = tit.fit_plate(label=\"2\", method=\"lm\")\ntr_glob = tit.fit_plate(method=\"lm\")\ntr_odr = tit.fit_plate(method=\"odr\")\n\n# Access result objects and figures\nwell = \"D10\"\nsingle1 = tr1[well]\nsingle2 = tr2[well]\nglob = tr_glob[well]\nodr = tr_odr[well]\n\n# Display figures inline\nprint(f\"Reduced X2: {single2.result.redchi:.3f}\")\nsingle2.figure"
+   "source": [
+    "# Fit each label and the global dataset; plate metadata comes from the titration\n",
+    "tr1 = tit.fit_plate(label=\"1\", method=\"lm\")\n",
+    "tr2 = tit.fit_plate(label=\"2\", method=\"lm\")\n",
+    "tr_glob = tit.fit_plate(method=\"lm\")\n",
+    "tr_odr = tit.fit_plate(method=\"odr\")\n",
+    "\n",
+    "# Access result objects and figures\n",
+    "well = \"D10\"\n",
+    "single1 = tr1[well]\n",
+    "single2 = tr2[well]\n",
+    "glob = tr_glob[well]\n",
+    "odr = tr_odr[well]\n",
+    "\n",
+    "# Display figures inline\n",
+    "print(f\"Reduced X2: {single2.result.redchi:.3f}\")\n",
+    "single2.figure"
+   ]
   },
   {
    "cell_type": "code",
@@ -295,7 +312,14 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Only fit D10 to avoid computing MCMC for the entire plate\nds_mcmc = {\"D10\": tit.create_global_ds(\"D10\")}\ntr_mcmc = tit.fit_plate(ds_mcmc, method=\"mcmc\")\n\nfr_mcmc = tr_mcmc[well]\nfr_mcmc.mini"
+   "source": [
+    "# Only fit D10 to avoid computing MCMC for the entire plate\n",
+    "ds_mcmc = {\"D10\": tit.create_global_ds(\"D10\")}\n",
+    "tr_mcmc = tit.fit_plate(ds_mcmc, method=\"mcmc\")\n",
+    "\n",
+    "fr_mcmc = tr_mcmc[well]\n",
+    "fr_mcmc.mini"
+   ]
   },
   {
    "cell_type": "code",
@@ -455,7 +479,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from clophfit.fitting.model_validation import ResidualDiagnostics\n\ndiag = ResidualDiagnostics(tr_glob.residuals)\ndiag.normality()"
+   "source": [
+    "from clophfit.fitting.model_validation import ResidualDiagnostics\n",
+    "\n",
+    "diag = ResidualDiagnostics(tr_glob.residuals)\n",
+    "diag.normality()"
+   ]
   },
   {
    "cell_type": "code",
@@ -776,7 +805,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "tr_glob_cl = cl_an.fit_plate(method=\"lm\")\nfres = tr_glob_cl[\"D10\"]\nprint(fres.is_valid(), fres.result.bic, fres.result.redchi)\nfres.figure"
+   "source": [
+    "tr_glob_cl = cl_an.fit_plate(method=\"lm\")\n",
+    "fres = tr_glob_cl[\"D10\"]\n",
+    "print(fres.is_valid(), fres.result.bic, fres.result.redchi)\n",
+    "fres.figure"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/docs/tutorials/prtecan.ipynb
+++ b/docs/tutorials/prtecan.ipynb
@@ -259,38 +259,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from clophfit.fitting.pipeline import fit_plate\n",
-    "from clophfit.prtecan import TitrationResults\n",
-    "\n",
-    "# Create dataset dicts\n",
-    "ds_dict1 = tit.create_dataset_dict(\"1\")\n",
-    "ds_dict2 = tit.create_dataset_dict(\"2\")\n",
-    "ds_dict_glob = tit.create_dataset_dict()\n",
-    "\n",
-    "# Compute fits\n",
-    "res1 = fit_plate(ds_dict1, method=\"lm\")\n",
-    "res2 = fit_plate(ds_dict2, method=\"lm\")\n",
-    "res_glob = fit_plate(ds_dict_glob, method=\"lm\")\n",
-    "res_odr = fit_plate(ds_dict_glob, method=\"odr\")\n",
-    "\n",
-    "# Create TitrationResults wrappers for dataframe access\n",
-    "tr1 = TitrationResults(tit.scheme, tit.fit_keys, res1)\n",
-    "tr2 = TitrationResults(tit.scheme, tit.fit_keys, res2)\n",
-    "tr_glob = TitrationResults(tit.scheme, tit.fit_keys, res_glob)\n",
-    "tr_odr = TitrationResults(tit.scheme, tit.fit_keys, res_odr)\n",
-    "\n",
-    "# Access result objects and figures\n",
-    "well = \"D10\"\n",
-    "single1 = tr1[well]\n",
-    "single2 = tr2[well]\n",
-    "glob = tr_glob[well]\n",
-    "odr = tr_odr[well]\n",
-    "\n",
-    "# Display figures inline\n",
-    "print(f\"Reduced X2: {single2.result.redchi:.3f}\")\n",
-    "single2.figure"
-   ]
+   "source": "# Fit each label and the global dataset; plate metadata comes from the titration\ntr1 = tit.fit_plate(label=\"1\", method=\"lm\")\ntr2 = tit.fit_plate(label=\"2\", method=\"lm\")\ntr_glob = tit.fit_plate(method=\"lm\")\ntr_odr = tit.fit_plate(method=\"odr\")\n\n# Access result objects and figures\nwell = \"D10\"\nsingle1 = tr1[well]\nsingle2 = tr2[well]\nglob = tr_glob[well]\nodr = tr_odr[well]\n\n# Display figures inline\nprint(f\"Reduced X2: {single2.result.redchi:.3f}\")\nsingle2.figure"
   },
   {
    "cell_type": "code",
@@ -326,15 +295,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Only fit D10 to avoid computing MCMC for the entire plate\n",
-    "ds_mcmc = {\"D10\": tit.create_global_ds(\"D10\")}\n",
-    "res_mcmc = fit_plate(ds_mcmc, method=\"mcmc\")\n",
-    "tr_mcmc = TitrationResults(tit.scheme, tit.fit_keys, res_mcmc)\n",
-    "\n",
-    "fr_mcmc = tr_mcmc[well]\n",
-    "fr_mcmc.mini"
-   ]
+   "source": "# Only fit D10 to avoid computing MCMC for the entire plate\nds_mcmc = {\"D10\": tit.create_global_ds(\"D10\")}\ntr_mcmc = tit.fit_plate(ds_mcmc, method=\"mcmc\")\n\nfr_mcmc = tr_mcmc[well]\nfr_mcmc.mini"
   },
   {
    "cell_type": "code",
@@ -494,21 +455,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from clophfit.fitting.model_validation import (\n",
-    "    ResidualDiagnostics,\n",
-    "    residuals_from_fit_results,\n",
-    ")\n",
-    "from clophfit.fitting.models import binding_1site\n",
-    "\n",
-    "all_res = residuals_from_fit_results(\n",
-    "    {w: tr_glob[w] for w in tit.fit_keys},\n",
-    "    trace_id=\"\",\n",
-    "    binding_function=binding_1site,\n",
-    ")\n",
-    "diag = ResidualDiagnostics(all_res)\n",
-    "diag.normality()"
-   ]
+   "source": "from clophfit.fitting.model_validation import ResidualDiagnostics\n\ndiag = ResidualDiagnostics(tr_glob.residuals)\ndiag.normality()"
   },
   {
    "cell_type": "code",
@@ -829,15 +776,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "ds_glob_cl = cl_an.create_dataset_dict()\n",
-    "tr_glob_cl = prtecan.TitrationResults(\n",
-    "    cl_an.scheme, cl_an.fit_keys, fit_plate(ds_glob_cl, method=\"lm\")\n",
-    ")\n",
-    "fres = tr_glob_cl[\"D10\"]\n",
-    "print(fres.is_valid(), fres.result.bic, fres.result.redchi)\n",
-    "fres.figure"
-   ]
+   "source": "tr_glob_cl = cl_an.fit_plate(method=\"lm\")\nfres = tr_glob_cl[\"D10\"]\nprint(fres.is_valid(), fres.result.bic, fres.result.redchi)\nfres.figure"
   },
   {
    "cell_type": "markdown",

--- a/src/clophfit/fitting/data_structures.py
+++ b/src/clophfit/fitting/data_structures.py
@@ -25,6 +25,14 @@ from uncertainties import ufloat  # type: ignore[import-untyped]
 # Re-exported for back-compat: MiniT lives in the leaf ``clophfit_types`` module
 # so it stays out of the fitting-package import cycle (see its definition there).
 from clophfit.clophfit_types import MiniT as MiniT  # noqa: PLC0414
+from clophfit.fitting.model_validation import (
+    STUDENT_T_NU,
+    residuals_from_fit_results,
+    residuals_from_multifit,
+    robust_likelihood_from_trace,
+    robust_settings_from_trace,
+)
+from clophfit.fitting.models import binding_1site
 
 from .errors import InvalidDataError
 
@@ -565,21 +573,16 @@ class FitResult[MiniType: MiniProtocol]:
         pd.DataFrame
             The canonical residual table (see :attr:`residuals`).
         """
-        from clophfit.fitting import model_validation  # noqa: PLC0415
-        from clophfit.fitting.models import binding_1site  # noqa: PLC0415
-
         bfunc = binding_1site if binding_function is None else binding_function
         residual_likelihood: str | None = None
         if robust is None:
-            residual_likelihood = model_validation.robust_likelihood_from_trace(
-                self.mini
-            )
-            robust, detected_nu = model_validation.robust_settings_from_trace(self.mini)
+            residual_likelihood = robust_likelihood_from_trace(self.mini)
+            robust, detected_nu = robust_settings_from_trace(self.mini)
             if student_t_nu is None:
                 student_t_nu = detected_nu
         if student_t_nu is None:
-            student_t_nu = model_validation.STUDENT_T_NU
-        return model_validation.residuals_from_fit_results(
+            student_t_nu = STUDENT_T_NU
+        return residuals_from_fit_results(
             {well: self},
             trace_id="",
             binding_function=bfunc,
@@ -647,23 +650,16 @@ class MultiFitResult:
         pd.DataFrame
             The canonical residual table (see :attr:`residuals`).
         """
-        from clophfit.fitting import model_validation  # noqa: PLC0415
-        from clophfit.fitting.models import binding_1site  # noqa: PLC0415
-
         bfunc = binding_1site if binding_function is None else binding_function
         residual_likelihood: str | None = None
         if robust is None:
-            residual_likelihood = model_validation.robust_likelihood_from_trace(
-                self.trace
-            )
-            robust, detected_nu = model_validation.robust_settings_from_trace(
-                self.trace
-            )
+            residual_likelihood = robust_likelihood_from_trace(self.trace)
+            robust, detected_nu = robust_settings_from_trace(self.trace)
             if student_t_nu is None:
                 student_t_nu = detected_nu
         if student_t_nu is None:
-            student_t_nu = model_validation.STUDENT_T_NU
-        return model_validation.residuals_from_multifit(
+            student_t_nu = STUDENT_T_NU
+        return residuals_from_multifit(
             self,
             trace_id="",
             binding_function=bfunc,

--- a/src/clophfit/fitting/data_structures.py
+++ b/src/clophfit/fitting/data_structures.py
@@ -15,7 +15,7 @@ from collections import UserDict
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, TypeVar, cast, runtime_checkable
+from typing import TYPE_CHECKING, NamedTuple, Protocol, TypeVar, cast, runtime_checkable
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -494,8 +494,80 @@ class MiniProtocol(Protocol):
 MiniType = TypeVar("MiniType", bound=MiniProtocol)
 
 
+class _ResidualSettings(NamedTuple):
+    """Resolved settings for building a canonical residual table."""
+
+    binding_function: Callable[..., object]
+    robust: bool
+    student_t_nu: float
+    residual_likelihood: str | None
+
+
+class ResidualsMixin:
+    """Shared canonical-residual accessor for fit-result containers.
+
+    Subclasses must implement :meth:`residual_table`. They may add extra
+    keyword-only parameters to it (``FitResult`` adds ``well``).
+    """
+
+    @cached_property
+    def residuals(self) -> pd.DataFrame:
+        """Canonical per-observation residual table for this fit.
+
+        Lazily computed, cached, and returned in the schema shared across the
+        package (``clophfit.fitting.model_validation.RESIDUAL_TABLE_COLUMNS``:
+        ``raw_res``, ``yhat``, ``sigma``, ``std_res``, …). Robustness is
+        auto-detected. Use :meth:`residual_table` to override the model or the
+        robust settings.
+        """
+        return self.residual_table()
+
+    def residual_table(self) -> pd.DataFrame:
+        """Compute the canonical residual table. Implemented by subclasses."""
+        raise NotImplementedError
+
+    @staticmethod
+    def _resolve_residual_settings(
+        trace: object,
+        *,
+        binding_function: Callable[..., object] | None = None,
+        robust: bool | None = None,
+        student_t_nu: float | None = None,
+    ) -> _ResidualSettings:
+        """Resolve model and standardization settings for a residual table.
+
+        Parameters
+        ----------
+        trace : object
+            PyMC trace to auto-detect robustness from, or ``None`` for a
+            classical fit (which resolves to Normal standardization).
+        binding_function : Callable[..., object] | None
+            Model evaluated for ``yhat``; defaults to ``binding_1site``.
+        robust : bool | None
+            Force the Student-t standardization of ``std_res``. ``None``
+            auto-detects from *trace*.
+        student_t_nu : float | None
+            Student-t degrees of freedom. ``None`` uses the detected/default.
+
+        Returns
+        -------
+        _ResidualSettings
+            The resolved binding function, robust flag, nu, and likelihood label.
+        """
+        bfunc = binding_1site if binding_function is None else binding_function
+        residual_likelihood: str | None = None
+        if robust is None:
+            residual_likelihood = robust_likelihood_from_trace(trace)
+            robust, detected_nu = robust_settings_from_trace(trace)
+            if student_t_nu is None:
+                student_t_nu = detected_nu
+        if student_t_nu is None:
+            student_t_nu = STUDENT_T_NU
+        return _ResidualSettings(bfunc, robust, student_t_nu, residual_likelihood)
+
+
 @dataclass
-class FitResult[MiniType: MiniProtocol]:
+class FitResult[MiniType: MiniProtocol](ResidualsMixin):
     """Result container of a fitting procedure."""
 
     figure: Figure | None = None
@@ -530,18 +602,6 @@ class FitResult[MiniType: MiniProtocol]:
             and self.mini is not None
         )
 
-    @cached_property
-    def residuals(self) -> pd.DataFrame:
-        """Canonical per-observation residual table for this fit.
-
-        Lazily computed, cached, and returned in the schema shared across the
-        package (``clophfit.fitting.model_validation.RESIDUAL_TABLE_COLUMNS``:
-        ``raw_res``, ``yhat``, ``sigma``, ``std_res``, …). Works for both LMFit
-        and PyMC fits; robustness is auto-detected from the trace. Use
-        :meth:`residual_table` to override the model or robust settings.
-        """
-        return self.residual_table()
-
     def residual_table(
         self,
         *,
@@ -573,29 +633,26 @@ class FitResult[MiniType: MiniProtocol]:
         pd.DataFrame
             The canonical residual table (see :attr:`residuals`).
         """
-        bfunc = binding_1site if binding_function is None else binding_function
-        residual_likelihood: str | None = None
-        if robust is None:
-            residual_likelihood = robust_likelihood_from_trace(self.mini)
-            robust, detected_nu = robust_settings_from_trace(self.mini)
-            if student_t_nu is None:
-                student_t_nu = detected_nu
-        if student_t_nu is None:
-            student_t_nu = STUDENT_T_NU
+        settings = self._resolve_residual_settings(
+            self.mini,
+            binding_function=binding_function,
+            robust=robust,
+            student_t_nu=student_t_nu,
+        )
         return residuals_from_fit_results(
             {well: self},
             trace_id="",
-            binding_function=bfunc,
-            robust=robust,
-            student_t_nu=student_t_nu,
+            binding_function=settings.binding_function,
+            robust=settings.robust,
+            student_t_nu=settings.student_t_nu,
             outlier_threshold=outlier_threshold,
             trace=self.mini,
-            residual_likelihood=residual_likelihood,
+            residual_likelihood=settings.residual_likelihood,
         )
 
 
 @dataclass
-class MultiFitResult:
+class MultiFitResult(ResidualsMixin):
     """Container for multi-well Bayesian results.
 
     Parameters
@@ -612,17 +669,6 @@ class MultiFitResult:
     def __getattr__(self, name: str) -> object:
         """Delegate trace attributes for convenient compatibility."""
         return getattr(self.trace, name)
-
-    @cached_property
-    def residuals(self) -> pd.DataFrame:
-        """Canonical per-observation residual table across all wells.
-
-        Lazily computed, cached, and returned in the shared schema
-        (``RESIDUAL_TABLE_COLUMNS``, including ``p_outlier`` extracted
-        from the trace). Robustness is auto-detected; use :meth:`residual_table`
-        to override.
-        """
-        return self.residual_table()
 
     def residual_table(
         self,
@@ -650,23 +696,20 @@ class MultiFitResult:
         pd.DataFrame
             The canonical residual table (see :attr:`residuals`).
         """
-        bfunc = binding_1site if binding_function is None else binding_function
-        residual_likelihood: str | None = None
-        if robust is None:
-            residual_likelihood = robust_likelihood_from_trace(self.trace)
-            robust, detected_nu = robust_settings_from_trace(self.trace)
-            if student_t_nu is None:
-                student_t_nu = detected_nu
-        if student_t_nu is None:
-            student_t_nu = STUDENT_T_NU
+        settings = self._resolve_residual_settings(
+            self.trace,
+            binding_function=binding_function,
+            robust=robust,
+            student_t_nu=student_t_nu,
+        )
         return residuals_from_multifit(
             self,
             trace_id="",
-            binding_function=bfunc,
-            robust=robust,
-            student_t_nu=student_t_nu,
+            binding_function=settings.binding_function,
+            robust=settings.robust,
+            student_t_nu=settings.student_t_nu,
             outlier_threshold=outlier_threshold,
-            residual_likelihood=residual_likelihood,
+            residual_likelihood=settings.residual_likelihood,
         )
 
 

--- a/src/clophfit/fitting/pipeline.py
+++ b/src/clophfit/fitting/pipeline.py
@@ -5,7 +5,6 @@ import typing
 
 import pandas as pd
 
-from clophfit.fitting.bayes import fit_binding_pymc
 from clophfit.fitting.core import fit_binding_glob
 from clophfit.fitting.data_structures import (
     Dataset,
@@ -16,7 +15,6 @@ from clophfit.fitting.data_structures import (
 from clophfit.fitting.errors import InsufficientDataError
 from clophfit.fitting.model_validation import residuals_from_fit_results
 from clophfit.fitting.models import binding_1site
-from clophfit.fitting.odr import fit_binding_odr
 from clophfit.fitting.utils import (
     compute_plate_slopes,
     fit_gain_from_residuals,
@@ -225,56 +223,3 @@ def fgls_plate_fit(  # noqa: PLR0913
         noise_model = new_noise
 
     return results, noise_model  # type: ignore[return-value]
-
-
-def fit_plate(
-    datasets: dict[str, Dataset],
-    method: str = "",
-    **kwargs: typing.Any,  # noqa: ANN401
-) -> dict[str, FitResult[typing.Any]]:
-    """Run a single-pass fit on an entire plate of datasets.
-
-    Parameters
-    ----------
-    datasets : dict[str, Dataset]
-        A mapping of well keys (e.g. 'A01') to `Dataset` objects.
-    method : str
-        The fitting method to use: 'lm' (default), 'huber', 'odr', or 'mcmc'.
-        Other methods supported by :func:`clophfit.fitting.core.fit_binding_glob`
-        may also be used.
-    **kwargs : typing.Any
-        Additional keyword arguments passed to the specific fitting function.
-
-    Returns
-    -------
-    dict[str, FitResult[typing.Any]]
-        A dictionary mapping well keys to their corresponding `FitResult`.
-    """
-    results: dict[str, FitResult[typing.Any]] = {}
-
-    if method == "odr":
-        for well, ds in datasets.items():
-            try:
-                results[well] = fit_binding_odr(ds, **kwargs)
-            except InsufficientDataError:
-                logger.warning("Skip ODR fit for well %s.", well)
-                results[well] = FitResult()
-    elif method == "mcmc":
-        for well, ds in datasets.items():
-            try:
-                results[well] = fit_binding_pymc(ds, **kwargs)
-            except InsufficientDataError:
-                logger.warning("Skip MCMC fit for well %s.", well)
-                results[well] = FitResult()
-    else:
-        if not method:
-            method = "lm"
-        print(method)
-        for well, ds in datasets.items():
-            try:
-                results[well] = fit_binding_glob(ds, method=method, **kwargs)
-            except InsufficientDataError:
-                logger.warning("Skip fit for well %s.", well)
-                results[well] = FitResult()
-
-    return results

--- a/src/clophfit/prtecan/export.py
+++ b/src/clophfit/prtecan/export.py
@@ -16,7 +16,6 @@ from clophfit.fitting.data_structures import FitResult
 from clophfit.fitting.diagnostics import detect_bad_wells
 from clophfit.fitting.model_validation import residuals_from_fit_results
 from clophfit.fitting.models import binding_1site
-from clophfit.fitting.pipeline import fit_plate
 from clophfit.fitting.residuals import (
     plot_residual_vs_predicted,
     plot_residual_vs_yerr,
@@ -175,13 +174,12 @@ def export_fit(titration: Titration, subfolder: Path, config: TecanConfig) -> No
             ds_single = {
                 k: titration.create_ds(k, label=label) for k in titration.fit_keys
             }
-            fits = fit_plate(
-                ds_single,
-                method=titration.params.fit_method,
-                remove_outliers=titration.params.outlier,
-            )
             export_list.append(
-                TitrationResults(titration.scheme, titration.fit_keys, fits)
+                titration.fit_plate(
+                    ds_single,
+                    method=titration.params.fit_method,
+                    remove_outliers=titration.params.outlier,
+                )
             )
 
     method = (
@@ -191,22 +189,20 @@ def export_fit(titration: Titration, subfolder: Path, config: TecanConfig) -> No
     )
     reweight = "irls" if titration.params.fit_method == "irls" else None
 
-    global_fits = fit_plate(
+    global_res = titration.fit_plate(
         datasets,
         method=method,
         reweight=reweight,
         remove_outliers=titration.params.outlier,
     )
-    global_res = TitrationResults(titration.scheme, titration.fit_keys, global_fits)
     export_list.append(global_res)
 
-    odr_fits = fit_plate(
+    odr_res = titration.fit_plate(
         datasets,
         method="odr",
         remove_outliers=titration.params.outlier,
         reweight=reweight,
     )
-    odr_res = TitrationResults(titration.scheme, titration.fit_keys, odr_fits)
     export_list.append(odr_res)
 
     mcmc_res = fit_single_mcmc(titration, datasets, outfit)

--- a/src/clophfit/prtecan/titration.py
+++ b/src/clophfit/prtecan/titration.py
@@ -28,7 +28,7 @@ from clophfit.fitting.data_structures import (
     ResidualsMixin,
 )
 from clophfit.fitting.errors import InsufficientDataError
-from clophfit.fitting.model_validation import residuals_from_fit_results
+from clophfit.fitting.model_validation import RESIDUAL_TABLE_COLUMNS
 from clophfit.fitting.odr import fit_binding_odr, format_estimate
 from clophfit.fitting.plotting import PlotParameters
 from clophfit.fitting.utils import (
@@ -88,20 +88,20 @@ def _fit_datasets(
     """
     fitter: Callable[..., FitResult[typing.Any]]
     if method == "odr":
-        fitter, label = fit_binding_odr, "ODR fit"
+        fitter, fit_kind = fit_binding_odr, "ODR fit"
     elif method == "mcmc":
-        fitter, label = fit_binding_pymc, "MCMC fit"
+        fitter, fit_kind = fit_binding_pymc, "MCMC fit"
     else:
         method = method or "lm"
         fitter = functools.partial(fit_binding_glob, method=method)
-        label = "fit"
+        fit_kind = "fit"
 
     results: dict[str, FitResult[typing.Any]] = {}
     for well, ds in datasets.items():
         try:
             results[well] = fitter(ds, **kwargs)
         except InsufficientDataError:
-            logger.warning("Skip %s for well %s.", label, well)
+            logger.warning("Skip %s for well %s.", fit_kind, well)
             results[well] = FitResult()
     return results
 
@@ -499,13 +499,20 @@ class TitrationResults(ResidualsMixin):
     ) -> pd.DataFrame:
         """Compute the canonical plate-wide residual table.
 
+        Delegates to each well's own :meth:`FitResult.residual_table`, so
+        robustness is auto-detected per well from that well's own ``mini``
+        (its lmfit ``Minimizer``, ODR output, or PyMC trace). A plate fitted
+        with ``method="mcmc"`` therefore standardizes each well against its
+        own trace, instead of being forced to Normal standardization.
+
         Parameters
         ----------
         binding_function : Callable[..., object] | None
             Model evaluated for ``yhat``; defaults to ``binding_1site``.
+            Forwarded unchanged to each well.
         robust : bool | None
             Force the Student-t standardization of ``std_res``. ``None``
-            auto-detects, which for a classical plate fit means Normal.
+            auto-detects per well from that well's trace.
         student_t_nu : float | None
             Student-t degrees of freedom (``None`` uses detected/default).
         outlier_threshold : float
@@ -514,25 +521,25 @@ class TitrationResults(ResidualsMixin):
         Returns
         -------
         pd.DataFrame
-            The canonical residual table (see :attr:`residuals`). Wells whose
-            fit failed carry no dataset or result and are skipped, so the table
-            may cover fewer wells than ``fit_keys``.
+            The canonical residual table (see :attr:`residuals`), built by
+            concatenating each well's own table. Wells whose fit failed carry
+            no dataset or result and are skipped, so the table may cover
+            fewer wells than ``fit_keys``.
         """
-        settings = self._resolve_residual_settings(
-            None,
-            binding_function=binding_function,
-            robust=robust,
-            student_t_nu=student_t_nu,
-        )
-        return residuals_from_fit_results(
-            self.results,
-            trace_id="",
-            binding_function=settings.binding_function,
-            robust=settings.robust,
-            student_t_nu=settings.student_t_nu,
-            outlier_threshold=outlier_threshold,
-            residual_likelihood=settings.residual_likelihood,
-        )
+        tables = [
+            fr.residual_table(
+                well=well,
+                binding_function=binding_function,
+                robust=robust,
+                student_t_nu=student_t_nu,
+                outlier_threshold=outlier_threshold,
+            )
+            for well, fr in self.results.items()
+            if fr.dataset is not None and fr.result is not None
+        ]
+        if not tables:
+            return pd.DataFrame(columns=RESIDUAL_TABLE_COLUMNS)
+        return pd.concat(tables, ignore_index=True)
 
     @property
     def dataframe(self) -> pd.DataFrame:

--- a/src/clophfit/prtecan/titration.py
+++ b/src/clophfit/prtecan/titration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 import typing
 from dataclasses import InitVar, dataclass, field
@@ -16,6 +17,8 @@ import pandas as pd
 import seaborn as sns  # type: ignore[import-untyped]
 from matplotlib import figure
 
+from clophfit.fitting.bayes import fit_binding_pymc
+from clophfit.fitting.core import fit_binding_glob
 from clophfit.fitting.data_structures import (
     DataArray,
     Dataset,
@@ -24,8 +27,9 @@ from clophfit.fitting.data_structures import (
     PlateNoiseModel,
     ResidualsMixin,
 )
+from clophfit.fitting.errors import InsufficientDataError
 from clophfit.fitting.model_validation import residuals_from_fit_results
-from clophfit.fitting.odr import format_estimate
+from clophfit.fitting.odr import fit_binding_odr, format_estimate
 from clophfit.fitting.plotting import PlotParameters
 from clophfit.fitting.utils import apply_outlier_mask
 from clophfit.utils import weights_from_sigma
@@ -53,6 +57,48 @@ logger = logging.getLogger(__name__)
 # pH K bounds as used by _build_params_1site in fitting/core.py
 _PH_K_MIN: float = 3.0
 _PH_K_MAX: float = 11.0
+
+
+def _fit_datasets(
+    datasets: dict[str, Dataset],
+    method: str,
+    **kwargs: typing.Any,  # noqa: ANN401
+) -> dict[str, FitResult[typing.Any]]:
+    """Fit each dataset, turning per-well failures into empty results.
+
+    Parameters
+    ----------
+    datasets : dict[str, Dataset]
+        Mapping of well keys to `Dataset` objects.
+    method : str
+        'lm', 'huber', 'odr', 'mcmc', or any method accepted by
+        :func:`clophfit.fitting.core.fit_binding_glob`.
+    **kwargs : typing.Any
+        Forwarded to the selected fitting function.
+
+    Returns
+    -------
+    dict[str, FitResult[typing.Any]]
+        One entry per input well; failed wells hold an empty `FitResult`.
+    """
+    fitter: Callable[..., FitResult[typing.Any]]
+    if method == "odr":
+        fitter, label = fit_binding_odr, "ODR fit"
+    elif method == "mcmc":
+        fitter, label = fit_binding_pymc, "MCMC fit"
+    else:
+        method = method or "lm"
+        fitter = functools.partial(fit_binding_glob, method=method)
+        label = "fit"
+
+    results: dict[str, FitResult[typing.Any]] = {}
+    for well, ds in datasets.items():
+        try:
+            results[well] = fitter(ds, **kwargs)
+        except InsufficientDataError:
+            logger.warning("Skip %s for well %s.", label, well)
+            results[well] = FitResult()
+    return results
 
 
 @dataclass
@@ -1137,6 +1183,51 @@ class Titration(TecanfilesGroup):
                     ds, threshold=self.params.outlier_threshold
                 )
         return ds_dict
+
+    def fit_plate(
+        self,
+        datasets: dict[str, Dataset] | None = None,
+        method: str = "",
+        *,
+        label: str | None = None,
+        **kwargs: typing.Any,  # noqa: ANN401
+    ) -> TitrationResults:
+        """Run a single-pass fit on an entire plate of datasets.
+
+        Parameters
+        ----------
+        datasets : dict[str, Dataset] | None
+            Mapping of well keys (e.g. 'A01') to `Dataset` objects. When
+            ``None``, datasets are built with :meth:`create_dataset_dict`,
+            which also applies outlier masking when ``params.mask_outliers``
+            is set.
+        method : str
+            The fitting method: 'lm' (default), 'huber', 'odr', or 'mcmc'.
+            Other methods supported by
+            :func:`clophfit.fitting.core.fit_binding_glob` may also be used.
+        label : str | None
+            Build per-label datasets for this label instead of global ones.
+            Only valid when *datasets* is ``None``.
+        **kwargs : typing.Any
+            Additional keyword arguments passed to the fitting function.
+
+        Returns
+        -------
+        TitrationResults
+            Plate results carrying this titration's ``scheme`` and ``fit_keys``.
+
+        Raises
+        ------
+        ValueError
+            If both *datasets* and *label* are given.
+        """
+        if datasets is not None and label is not None:
+            msg = "Pass either `datasets` or `label`, not both."
+            raise ValueError(msg)
+        if datasets is None:
+            datasets = self.create_dataset_dict(label)
+        results = _fit_datasets(datasets, method, **kwargs)
+        return TitrationResults(self.scheme, self.fit_keys, results)
 
     def plot_temperature(self, title: str = "") -> figure.Figure:
         """Plot temperatures of all labelblocksgroups.

--- a/src/clophfit/prtecan/titration.py
+++ b/src/clophfit/prtecan/titration.py
@@ -22,7 +22,9 @@ from clophfit.fitting.data_structures import (
     FitResult,
     NoiseModelParams,
     PlateNoiseModel,
+    ResidualsMixin,
 )
+from clophfit.fitting.model_validation import residuals_from_fit_results
 from clophfit.fitting.odr import format_estimate
 from clophfit.fitting.plotting import PlotParameters
 from clophfit.fitting.utils import apply_outlier_mask
@@ -411,7 +413,7 @@ class Buffer:
 
 
 @dataclass
-class TitrationResults:
+class TitrationResults(ResidualsMixin):
     """Manage titration results with optional lazy computation.
 
     Provide either the small ``scheme`` + ``fit_keys`` directly, or a
@@ -435,6 +437,51 @@ class TitrationResults:
         if titration is not None:
             self.scheme = titration.scheme
             self.fit_keys = titration.fit_keys
+
+    def residual_table(
+        self,
+        *,
+        binding_function: Callable[..., object] | None = None,
+        robust: bool | None = None,
+        student_t_nu: float | None = None,
+        outlier_threshold: float = 3.0,
+    ) -> pd.DataFrame:
+        """Compute the canonical plate-wide residual table.
+
+        Parameters
+        ----------
+        binding_function : Callable[..., object] | None
+            Model evaluated for ``yhat``; defaults to ``binding_1site``.
+        robust : bool | None
+            Force the Student-t standardization of ``std_res``. ``None``
+            auto-detects, which for a classical plate fit means Normal.
+        student_t_nu : float | None
+            Student-t degrees of freedom (``None`` uses detected/default).
+        outlier_threshold : float
+            Threshold for the ``is_residual_outlier`` flag.
+
+        Returns
+        -------
+        pd.DataFrame
+            The canonical residual table (see :attr:`residuals`). Wells whose
+            fit failed carry no dataset or result and are skipped, so the table
+            may cover fewer wells than ``fit_keys``.
+        """
+        settings = self._resolve_residual_settings(
+            None,
+            binding_function=binding_function,
+            robust=robust,
+            student_t_nu=student_t_nu,
+        )
+        return residuals_from_fit_results(
+            self.results,
+            trace_id="",
+            binding_function=settings.binding_function,
+            robust=settings.robust,
+            student_t_nu=settings.student_t_nu,
+            outlier_threshold=outlier_threshold,
+            residual_likelihood=settings.residual_likelihood,
+        )
 
     @property
     def dataframe(self) -> pd.DataFrame:

--- a/src/clophfit/prtecan/titration.py
+++ b/src/clophfit/prtecan/titration.py
@@ -31,7 +31,12 @@ from clophfit.fitting.errors import InsufficientDataError
 from clophfit.fitting.model_validation import residuals_from_fit_results
 from clophfit.fitting.odr import fit_binding_odr, format_estimate
 from clophfit.fitting.plotting import PlotParameters
-from clophfit.fitting.utils import apply_outlier_mask
+from clophfit.fitting.utils import (
+    apply_outlier_mask,
+    flag_trend_outliers,
+    roughness,
+    smoothness,
+)
 from clophfit.utils import weights_from_sigma
 
 if TYPE_CHECKING:
@@ -782,12 +787,6 @@ class Titration(TecanfilesGroup):
         list[str]
             Newly discarded well keys.
         """
-        from clophfit.fitting.utils import (  # noqa: PLC0415
-            flag_trend_outliers,
-            roughness,
-            smoothness,
-        )
-
         first_label = next(iter(self.labelblocksgroups.keys()), None)
         if first_label is None:
             return []

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,30 @@
+"""Cold-import regression tests.
+
+Each import runs in a fresh interpreter so partially-initialized-package
+regressions surface instead of being masked by an already-populated
+``sys.modules``.
+"""
+
+from __future__ import annotations
+
+import subprocess  # noqa: S404
+import sys
+
+
+def _cold_import(statement: str) -> None:
+    subprocess.run([sys.executable, "-c", statement], check=True)  # noqa: S603
+
+
+def test_cold_import_fitting_package() -> None:
+    """Importing the package triggers the eager ``__init__`` chain."""
+    _cold_import("import clophfit.fitting")
+
+
+def test_cold_import_data_structures_first() -> None:
+    """Importing the submodule first must not hit a partial parent package."""
+    _cold_import("import clophfit.fitting.data_structures")
+
+
+def test_cold_import_prtecan() -> None:
+    """Prtecan imports fitting at module level; it must stay importable."""
+    _cold_import("import clophfit.prtecan")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from clophfit.fitting import pipeline
 from clophfit.fitting.data_structures import DataArray, Dataset, FitResult
 from clophfit.fitting.errors import InsufficientDataError
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def _dataset() -> Dataset:
@@ -52,68 +54,6 @@ def test_noise_model_building_and_convergence() -> None:
     assert not pipeline._noise_params_converged(  # noqa: SLF001
         old, missing, tol=1e-2
     )
-
-
-@pytest.mark.parametrize(
-    ("method", "target"),
-    [
-        ("", "lm"),
-        ("huber", "huber"),
-        ("odr", "odr"),
-        ("mcmc", "mcmc"),
-    ],
-)
-def test_fit_plate_routes_methods_and_preserves_well_keys(
-    monkeypatch: pytest.MonkeyPatch,
-    method: str,
-    target: str,
-) -> None:
-    """Plate fitting should dispatch each method to the intended backend."""
-    calls: list[tuple[str, str]] = []
-
-    def fake_glob(
-        ds: Dataset, *, method: str = "lm", **_kwargs: object
-    ) -> FitResult[Any]:
-        calls.append(("glob", method))
-        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
-
-    def fake_odr(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
-        calls.append(("odr", "odr"))
-        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
-
-    def fake_mcmc(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
-        calls.append(("mcmc", "mcmc"))
-        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
-
-    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_glob", fake_glob)
-    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_odr", fake_odr)
-    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_pymc", fake_mcmc)
-
-    results = pipeline.fit_plate({"A01": _dataset(), "A02": _dataset()}, method=method)
-
-    assert set(results) == {"A01", "A02"}
-    assert all(fr.result is not None for fr in results.values())
-    assert calls == [(target if target in {"odr", "mcmc"} else "glob", target)] * 2
-
-
-@pytest.mark.parametrize("method", ["lm", "odr", "mcmc"])
-def test_fit_plate_turns_insufficient_data_into_empty_result(
-    monkeypatch: pytest.MonkeyPatch,
-    method: str,
-) -> None:
-    """Per-well insufficient-data failures should not abort the whole plate."""
-
-    def fail(*_args: object, **_kwargs: object) -> FitResult[Any]:
-        msg = "too few points"
-        raise InsufficientDataError(msg)
-
-    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_glob", fail)
-    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_odr", fail)
-    monkeypatch.setattr("clophfit.fitting.pipeline.fit_binding_pymc", fail)
-
-    results = pipeline.fit_plate({"A01": _dataset()}, method=method)
-
-    assert results["A01"].result is None
 
 
 def test_fgls_plate_fit_uses_calibration_fallback_and_second_pass(

--- a/tests/test_prtecan.py
+++ b/tests/test_prtecan.py
@@ -1334,6 +1334,16 @@ class TestTitrationAnalysis:
         assert "H02" in set(table["well"])
         assert res.residuals is table  # cached
 
+    def test_titration_results_residuals_classical_plate(self, tit: Titration) -> None:
+        """A classical (non-MCMC) plate fit standardizes every well as Normal."""
+        res = tit.fit_plate(method="huber")
+
+        table = res.residuals
+
+        assert list(table.columns) == RESIDUAL_TABLE_COLUMNS
+        assert set(table["well"]) == tit.fit_keys
+        assert (table["residual_likelihood"] == "normal").all()
+
     def test_plot_buffer_with_title(self, tit: Titration) -> None:
         """It plots buffers for 2 lbg with title."""
         g = tit.buffer.plot(title="Test Title")

--- a/tests/test_prtecan.py
+++ b/tests/test_prtecan.py
@@ -16,6 +16,7 @@ from numpy.testing import assert_allclose, assert_almost_equal, assert_array_equ
 
 from clophfit import prtecan
 from clophfit.fitting.data_structures import FitResult
+from clophfit.fitting.model_validation import RESIDUAL_TABLE_COLUMNS
 from clophfit.fitting.pipeline import fit_plate
 from clophfit.prtecan import (
     Buffer,
@@ -1320,6 +1321,19 @@ class TestTitrationAnalysis:
         k_e02_glob = res_global["E02"].result.params["K"]
         assert k_e02_glob.value == pytest.approx(8.000, abs=1e-3)
         assert k_e02_glob.stderr == pytest.approx(0.031, abs=1e-3)
+
+    def test_titration_results_residuals(self, tit: Titration) -> None:
+        """Plate results expose the canonical residual table."""
+        ds = {k: tit.create_ds(k, label="2") for k in tit.fit_keys}
+        res = TitrationResults(tit.scheme, tit.fit_keys, fit_plate(ds, method="huber"))
+
+        table = res.residuals
+
+        assert list(table.columns) == RESIDUAL_TABLE_COLUMNS
+        assert not table.empty
+        # H02 fits on label 2; wells whose fit failed are skipped, not raised on.
+        assert "H02" in set(table["well"])
+        assert res.residuals is table  # cached
 
     def test_plot_buffer_with_title(self, tit: Titration) -> None:
         """It plots buffers for 2 lbg with title."""

--- a/tests/test_prtecan.py
+++ b/tests/test_prtecan.py
@@ -17,7 +17,6 @@ from numpy.testing import assert_allclose, assert_almost_equal, assert_array_equ
 from clophfit import prtecan
 from clophfit.fitting.data_structures import FitResult
 from clophfit.fitting.model_validation import RESIDUAL_TABLE_COLUMNS
-from clophfit.fitting.pipeline import fit_plate
 from clophfit.prtecan import (
     Buffer,
     BufferFit,
@@ -1288,12 +1287,12 @@ class TestTitrationAnalysis:
         """It fits each label separately."""
         # Test Label 1 for H02 (should be skipped because of OVER value or insufficient points)
         ds1 = {k: tit.create_ds(k, label="1") for k in tit.fit_keys}
-        res1 = fit_plate(ds1, method="huber")
+        res1 = tit.fit_plate(ds1, method="huber")
         assert not res1["H02"].is_valid()
 
         # Test Label 2 for H02
         ds2 = {k: tit.create_ds(k, label="2") for k in tit.fit_keys}
-        res2 = fit_plate(ds2, method="huber")
+        res2 = tit.fit_plate(ds2, method="huber")
         assert res2["H02"].is_valid()
 
         # Check 'K' and std error for 'H02' in the second fit result
@@ -1304,7 +1303,7 @@ class TestTitrationAnalysis:
 
         # Check 'K' and std error for 'H02' in global fit
         ds_global = {k: tit.create_global_ds(k) for k in tit.fit_keys}
-        res_global = fit_plate(ds_global, method="huber")
+        res_global = tit.fit_plate(ds_global, method="huber")
         assert res_global["H02"].result is not None
         k_h02_glob = res_global["H02"].result.params["K"]
         assert k_h02_glob.value == pytest.approx(7.899, abs=1e-3)
@@ -1325,7 +1324,7 @@ class TestTitrationAnalysis:
     def test_titration_results_residuals(self, tit: Titration) -> None:
         """Plate results expose the canonical residual table."""
         ds = {k: tit.create_ds(k, label="2") for k in tit.fit_keys}
-        res = TitrationResults(tit.scheme, tit.fit_keys, fit_plate(ds, method="huber"))
+        res = tit.fit_plate(ds, method="huber")
 
         table = res.residuals
 

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -712,3 +712,27 @@ def test_fgls_plate_fit_workflow() -> None:
     assert noise_params["1"].sigma_floor == 1.0
     assert noise_params["1"].gain >= 0.0
     assert noise_params["1"].alpha >= 0.0
+
+
+def test_residuals_mixin_resolves_classical_fit_as_normal() -> None:
+    """A classical fit has no trace, so it standardizes as Normal."""
+    from clophfit.fitting.data_structures import ResidualsMixin  # noqa: PLC0415
+
+    settings = ResidualsMixin._resolve_residual_settings(None)  # noqa: SLF001
+
+    assert settings.robust is False
+    assert settings.student_t_nu == 3.0
+    assert settings.residual_likelihood == "normal"
+
+
+def test_residuals_mixin_honours_explicit_robust() -> None:
+    """An explicit robust flag skips auto-detection and its likelihood label."""
+    from clophfit.fitting.data_structures import ResidualsMixin  # noqa: PLC0415
+
+    settings = ResidualsMixin._resolve_residual_settings(  # noqa: SLF001
+        None, robust=True, student_t_nu=5.0
+    )
+
+    assert settings.robust is True
+    assert settings.student_t_nu == 5.0
+    assert settings.residual_likelihood is None

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -15,6 +15,7 @@ from clophfit.fitting.data_structures import (
     FitResult,
     NoiseModelParams,
     PlateNoiseModel,
+    ResidualsMixin,
 )
 from clophfit.fitting.model_validation import (
     ResidualAnalysis,
@@ -716,8 +717,6 @@ def test_fgls_plate_fit_workflow() -> None:
 
 def test_residuals_mixin_resolves_classical_fit_as_normal() -> None:
     """A classical fit has no trace, so it standardizes as Normal."""
-    from clophfit.fitting.data_structures import ResidualsMixin  # noqa: PLC0415
-
     settings = ResidualsMixin._resolve_residual_settings(None)  # noqa: SLF001
 
     assert settings.robust is False
@@ -727,8 +726,6 @@ def test_residuals_mixin_resolves_classical_fit_as_normal() -> None:
 
 def test_residuals_mixin_honours_explicit_robust() -> None:
     """An explicit robust flag skips auto-detection and its likelihood label."""
-    from clophfit.fitting.data_structures import ResidualsMixin  # noqa: PLC0415
-
     settings = ResidualsMixin._resolve_residual_settings(  # noqa: SLF001
         None, robust=True, student_t_nu=5.0
     )

--- a/tests/test_titration_fit_plate.py
+++ b/tests/test_titration_fit_plate.py
@@ -74,19 +74,26 @@ def test_fit_plate_routes_methods_and_preserves_well_keys(
 def test_fit_plate_turns_insufficient_data_into_empty_result(
     monkeypatch: pytest.MonkeyPatch, tit: Titration, method: str
 ) -> None:
-    """Per-well insufficient-data failures should not abort the whole plate."""
+    """One well's insufficient-data failure must not abort the other well's fit."""
 
-    def fail(*_args: object, **_kwargs: object) -> FitResult[Any]:
-        msg = "too few points"
-        raise InsufficientDataError(msg)
+    def backend(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+        if len(ds["1"].y) < len(_dataset()["1"].y):
+            msg = "too few points"
+            raise InsufficientDataError(msg)
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
 
-    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_glob", fail)
-    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_odr", fail)
-    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_pymc", fail)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_glob", backend)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_odr", backend)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_pymc", backend)
 
-    results = tit.fit_plate({"A01": _dataset()}, method=method)
+    failing_ds = Dataset(
+        {"1": DataArray(np.array([6.0]), np.array([1.0]), y_errc=np.array([1.0]))},
+        is_ph=True,
+    )
+    results = tit.fit_plate({"A01": failing_ds, "A02": _dataset()}, method=method)
 
     assert results["A01"].result is None
+    assert results["A02"].result is not None
 
 
 def test_fit_plate_carries_plate_metadata(

--- a/tests/test_titration_fit_plate.py
+++ b/tests/test_titration_fit_plate.py
@@ -1,0 +1,135 @@
+"""Tests for Titration.fit_plate dispatch and dataset construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from clophfit.fitting.data_structures import DataArray, Dataset, FitResult
+from clophfit.fitting.errors import InsufficientDataError
+from clophfit.prtecan.titration import Titration, TitrationResults
+
+data_tests = Path(__file__).parent / "Tecan"
+
+
+@dataclass
+class _Result:
+    residual: np.ndarray
+    success: bool = True
+
+
+@pytest.fixture(scope="module")
+def tit() -> Titration:
+    """Build a small pH titration; the fits themselves are monkeypatched away."""
+    return Titration.fromlistfile(data_tests / "L1" / "list.pH.csv", is_ph=True)
+
+
+def _dataset() -> Dataset:
+    x = np.array([6.0, 7.0, 8.0])
+    y = np.array([1.0, 2.0, 3.0])
+    return Dataset({"1": DataArray(x, y, y_errc=np.ones_like(y))}, is_ph=True)
+
+
+@pytest.mark.parametrize(
+    ("method", "target"),
+    [("", "lm"), ("huber", "huber"), ("odr", "odr"), ("mcmc", "mcmc")],
+)
+def test_fit_plate_routes_methods_and_preserves_well_keys(
+    monkeypatch: pytest.MonkeyPatch, tit: Titration, method: str, target: str
+) -> None:
+    """Plate fitting should dispatch each method to the intended backend."""
+    calls: list[tuple[str, str]] = []
+
+    def fake_glob(
+        ds: Dataset, *, method: str = "lm", **_kwargs: object
+    ) -> FitResult[Any]:
+        calls.append(("glob", method))
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    def fake_odr(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+        calls.append(("odr", "odr"))
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    def fake_mcmc(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+        calls.append(("mcmc", "mcmc"))
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_glob", fake_glob)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_odr", fake_odr)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_pymc", fake_mcmc)
+
+    results = tit.fit_plate({"A01": _dataset(), "A02": _dataset()}, method=method)
+
+    assert isinstance(results, TitrationResults)
+    assert set(results.results) == {"A01", "A02"}
+    assert all(fr.result is not None for fr in results.results.values())
+    assert calls == [(target if target in {"odr", "mcmc"} else "glob", target)] * 2
+
+
+@pytest.mark.parametrize("method", ["lm", "odr", "mcmc"])
+def test_fit_plate_turns_insufficient_data_into_empty_result(
+    monkeypatch: pytest.MonkeyPatch, tit: Titration, method: str
+) -> None:
+    """Per-well insufficient-data failures should not abort the whole plate."""
+
+    def fail(*_args: object, **_kwargs: object) -> FitResult[Any]:
+        msg = "too few points"
+        raise InsufficientDataError(msg)
+
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_glob", fail)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_odr", fail)
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_pymc", fail)
+
+    results = tit.fit_plate({"A01": _dataset()}, method=method)
+
+    assert results["A01"].result is None
+
+
+def test_fit_plate_carries_plate_metadata(
+    monkeypatch: pytest.MonkeyPatch, tit: Titration
+) -> None:
+    """The returned container carries this titration's scheme and fit_keys."""
+
+    def fake_glob(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+        return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
+
+    monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_glob", fake_glob)
+
+    results = tit.fit_plate({"A01": _dataset()})
+
+    assert results.scheme is tit.scheme
+    assert results.fit_keys == tit.fit_keys
+
+
+def test_fit_plate_builds_datasets_when_none_given(
+    monkeypatch: pytest.MonkeyPatch, tit: Titration
+) -> None:
+    """Omitting datasets delegates construction to create_dataset_dict."""
+    seen: list[str | None] = []
+    original = tit.create_dataset_dict
+
+    def spy(label: str | None = None) -> dict[str, Dataset]:
+        seen.append(label)
+        return original(label)
+
+    monkeypatch.setattr(tit, "create_dataset_dict", spy)
+    monkeypatch.setattr(
+        "clophfit.prtecan.titration.fit_binding_glob",
+        lambda ds, **_kw: FitResult(
+            result=_Result(np.zeros(len(next(iter(ds.values())).y))), dataset=ds
+        ),
+    )
+
+    tit.fit_plate(label="1")
+
+    assert seen == ["1"]
+
+
+def test_fit_plate_rejects_datasets_and_label_together(tit: Titration) -> None:
+    """Datasets and label are alternative spellings of the same input."""
+    with pytest.raises(ValueError, match="not both"):
+        tit.fit_plate({"A01": _dataset()}, label="1")


### PR DESCRIPTION
## Summary

Gives plate-level fits a `.residuals` accessor matching `FitResult.residuals` and `MultiFitResult.residuals`, by moving `fit_plate` onto `Titration` and returning `TitrationResults` directly instead of a bare `dict[str, FitResult]`.

Before, every caller had to wrap the dict by hand with plate metadata it already had, then reach for `residuals_from_fit_results(...)` to get residuals. Now:

```python
res_glob = tit.fit_plate(method="huber")
res_glob.residuals          # canonical residual table, all wells
res_glob.plot_k()           # plate metadata still there
```

## What changed

- **`Titration.fit_plate(datasets=None, method="", *, label=None, **kwargs) -> TitrationResults`** — new method. `datasets=None` builds them from the titration via the existing `create_dataset_dict(label)`; an explicit dict is still accepted (needed for notebooks that mutate datasets pre-fit). Returns `TitrationResults`, collapsing the old fit-then-wrap boilerplate at every call site.
- **`ResidualsMixin`** (`fitting/data_structures.py`) — extracts the residual-settings auto-detection that was duplicated across `FitResult.residual_table` and `MultiFitResult.residual_table`; now shared by `FitResult`, `MultiFitResult`, and `TitrationResults`. Each class keeps its own precise `residual_table` signature.
- **`TitrationResults.residuals` / `.residual_table()`** — resolves **per well**, so each well auto-detects robustness from its own `FitResult.mini` (lmfit `Minimizer`, ODR output, or PyMC trace). A `method="mcmc"` plate is standardized correctly per well instead of being forced to Normal.
- **`pipeline.py`** — the free `fit_plate` is deleted, leaving only the FGLS orchestration its docstring actually describes. A stray `print(method)` went with it (ruff never caught it — `T20` is ignored).
- **Imports** — three redundant function-scoped imports hoisted to module level.
- Callers migrated: `prtecan/export.py`, `tests/`, and `docs/tutorials/prtecan.ipynb`.

`MultiFitResult` is deliberately left as-is: it is a PyMC trace proxy (delegates via `__getattr__`, reconstructs wells from one shared posterior), not a plate container. The schema is unified; the type is not.

## Behaviour preservation

- Classical (`lm`/`huber`/`odr`) plate residuals are **byte-for-byte identical** to before — verified with `pandas.testing.assert_frame_equal` (1337×17, 96 wells, no sorting needed).
- `export.py` masking is unchanged: its explicitly-built dataset dicts still skip `mask_outliers`; only the new `datasets=None` convenience path picks it up.
- `test_fit`'s K-value assertions (7.899 ± 0.026) are untouched and still pass, proving the move preserved fitting.

## Testing

- `uv run pytest tests/` → **572 passed**
- `uv run mypy src/clophfit` → clean (32 files)
- `docs/tutorials/prtecan.ipynb` executes end-to-end (64 cells, exit 0)
- End-to-end: `tit.fit_plate(method="huber").residuals` → 1337×17, all 96 wells, cached, plate metadata intact

Developed with an 8-task spec → plan → per-task review workflow, plus a whole-branch review. Design spec and plan are included under `docs/superpowers/` (excluded from the Sphinx build).

## Known follow-up (out of scope, deferred by owner)

`benchmarks/tecan_real_data_benchmark.py` still imports the deleted `pipeline.fit_plate` (ruff-excluded, not in CI). To be handled during a separate deep review of `benchmarks/`; note its line 346 also needs `.results` since `fit_binding_pymc_multi` expects a `Mapping` and `TitrationResults` is not one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
