### PR TITLE
refactor(fitting): split FitResult.mini into .mini/.trace/.odr, drop generic

### DIFF
--- a/docs/superpowers/specs/2026-07-17-fitresult-backend-fields-design.md
+++ b/docs/superpowers/specs/2026-07-17-fitresult-backend-fields-design.md
@@ -1,0 +1,205 @@
+# Split `FitResult.mini` into `.mini` / `.trace` / `.odr`
+
+- **Date:** 2026-07-17
+- **Status:** approved, pending implementation plan
+- **Scope:** `clophfit.clophfit_types`, `clophfit.fitting.data_structures`, `clophfit.fitting.core`, `clophfit.fitting.odr`, `clophfit.fitting.bayes`, `clophfit.__main__`, and the `FitResult[...]` annotations across `fitting/` and `testing/`
+- **Depends on:** PR #1398 (`feat/plate-fit-residuals`) merged to `main`. This spec edits `ResidualsMixin.residual_table`, which #1398 introduced. Branch off `main` after that merge.
+
+## Problem
+
+`FitResult` carries one field, `mini`, typed as a three-way union:
+
+```python
+# clophfit_types.py:20
+MiniT = Minimizer | odrpack.OdrResult | xr.DataTree
+```
+
+so a single attribute holds whichever backend produced the fit — an lmfit
+`Minimizer`, an `odrpack.OdrResult`, or a PyMC `xr.DataTree`. Every consumer
+must already know which one it holds and narrows by faith:
+
+- lmfit reads: `__main__.py:544` (`.mini.userargs`), `__main__.py:580`
+  (`conf_interval(mini, result)`), `__main__.py:684` / `core.py:345`
+  (`.mini.emcee(...)`).
+- ODR reads: `odr.py:233-257` (`.mini.res_var`, `outlier(.mini, ...)`).
+- Trace reads: `data_structures.py:637,649` — `ResidualsMixin.residual_table`
+  passes `self.mini` into `_resolve_residual_settings(trace=...)` and
+  `residuals_from_fit_results(trace=...)`, because for a PyMC fit `mini` *is*
+  the trace. `bayes.py:1960` assigns a trace *to* `.mini`
+  (`per_well_results[key].mini = trace`).
+
+Three problems follow:
+
+1. **The union is a footgun.** The field name says nothing about which backend
+   is present; correctness depends on each call site's unstated assumption. The
+   sharpest instance is `residual_table` passing a `Minimizer` into a parameter
+   literally named `trace`, relying on `_posterior_dataset_or_none` to reject
+   non-traces at runtime.
+
+1. **The generic machinery earns nothing.** `FitResult[MiniType: MiniProtocol]`
+   is parameterized over the backend, but **no code anywhere binds on
+   `MiniType` or `MiniProtocol`** (verified: zero uses outside
+   `data_structures.py`'s own definitions). All 81 `FitResult[...]` annotations
+   are documentation-only — the type parameter encodes which backend a result
+   carries, information that belongs in named fields.
+
+1. **`is_valid()` is backend-blind in the wrong direction.** It requires
+   `self.mini is not None` (`data_structures.py:602`), which is correct for
+   lmfit and ODR but would be *wrong* the moment the trace lived anywhere but
+   `mini`.
+
+## Design
+
+### 1. Three concrete fields, generic dropped
+
+```python
+@dataclass
+class FitResult:
+    figure: Figure | None = None
+    result: MinimizerResult | _Result | None = None
+    mini:  Minimizer | None = None      # lmfit Minimizer (conf_interval, emcee, userargs)
+    trace: xr.DataTree | None = None    # PyMC posterior trace
+    odr:   OdrResult | None = None      # odrpack output (res_var, outlier)
+    dataset: Dataset | None = None
+```
+
+`mini` narrows from the union to the lmfit `Minimizer` only. `trace` and `odr`
+are new. Note `mini` is the `Minimizer` object, **not** the
+`MinimizerResult` — that already lives in `result`.
+
+The new fields are inserted **after** `mini` and **before** `dataset`. This
+changes the positional signature, so every construction site moves to keyword
+arguments (§2) — a positional `FitResult(fig, result, mini, ds)` would
+otherwise bind `ds` to `trace`.
+
+The generic parameter is removed: `class FitResult:` (no `[MiniType: ...]`).
+
+### 2. Construction-site migration (6 sites)
+
+| Site            | Now                                                       | After                                                                  |
+| --------------- | --------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `core.py:285`   | `FitResult(fig, result, mini, ds)`                        | `FitResult(fig, result, mini=mini, dataset=ds)`                        |
+| `core.py:312`   | `FitResult(fig, f_res.result, f_res.mini)`                | `FitResult(fig, f_res.result, mini=f_res.mini)`                        |
+| `core.py:321`   | `FitResult(fig, f_res.result, f_res.mini)`                | `FitResult(fig, f_res.result, mini=f_res.mini)`                        |
+| `core.py:493`   | `FitResult(fig, result, mini, copy.deepcopy(ds_working))` | `FitResult(fig, result, mini=mini, dataset=copy.deepcopy(ds_working))` |
+| `odr.py:217`    | `FitResult(fig, _Result(...), output, ds)`                | `FitResult(fig, _Result(...), odr=output, dataset=ds)`                 |
+| `bayes.py:1651` | `FitResult(fig, _Result(...), mini, ds)`                  | `FitResult(fig, _Result(...), trace=mini, dataset=ds)`                 |
+
+Plus the post-construction assignment:
+
+| Site            | Now                                  | After                                 |
+| --------------- | ------------------------------------ | ------------------------------------- |
+| `bayes.py:1960` | `per_well_results[key].mini = trace` | `per_well_results[key].trace = trace` |
+
+At `bayes.py:1651` the local is named `mini` but holds a trace; rename the local
+to `trace` for clarity while migrating, or pass `trace=mini` — implementer's
+choice, but the field it lands in must be `trace`.
+
+### 3. Read-site migration (by backend)
+
+- **lmfit — stays `.mini`:** `core.py:281` (`mini = fit_result.mini`, later
+  `.emcee`), `core.py:343-345` (`f_res.mini.emcee`), `__main__.py:543-544`
+  (`is_valid()` + `.mini.userargs`), `__main__.py:580`
+  (`conf_interval(fit_result.mini, ...)`), `__main__.py:682-684`
+  (`f_res.mini.emcee`).
+- **ODR — becomes `.odr`:** `odr.py:233` (`ro.odr.res_var`), `odr.py:236-237`
+  (`ro.odr`, `outlier(ro.odr, ...)`), `odr.py:243,247,252,257`
+  (`rn.odr.res_var`, `outlier(rn.odr, ...)`).
+- **Trace — becomes `.trace`:** `ResidualsMixin.residual_table`
+  (`data_structures.py:637,649`) resolves and passes `self.trace` instead of
+  `self.mini`.
+
+### 4. `residual_table` becomes honest (behaviour-preserving)
+
+Before: `_resolve_residual_settings(self.mini, ...)` and
+`residuals_from_fit_results(..., trace=self.mini, ...)`. After: both use
+`self.trace`. For a classical fit `trace` is `None`, so
+`_resolve_residual_settings(None)` resolves to Normal standardization —
+identical to today, where a `Minimizer`/`OdrResult` in `mini` failed
+`_posterior_dataset_or_none` and degraded to `None`. For a PyMC fit `trace`
+is the `xr.DataTree`, exactly as `mini` was. **No behaviour change** — the
+parameter named `trace` now actually receives a trace.
+
+`MultiFitResult.residual_table` already uses `self.trace` (its own field) and
+is untouched.
+
+### 5. `is_valid()` becomes backend-agnostic
+
+```python
+def is_valid(self) -> bool:
+    """Whether a figure, a result, and at least one backend object exist."""
+    return (
+        self.figure is not None
+        and self.result is not None
+        and (self.mini is not None or self.trace is not None or self.odr is not None)
+    )
+```
+
+This preserves the current contract for lmfit/ODR (which set `mini`/`odr`) and
+fixes it for PyMC (which now sets `trace`, where before it set `mini` and so
+happened to pass). Update the docstring from "minimizer exist" accordingly.
+
+### 6. Type-machinery cleanup
+
+- Delete `MiniT` from `clophfit_types.py:20` and its six imports
+  (`__main__.py:52`, `odr.py:20`, `testing/evaluation.py:22`,
+  `fitting/plotting.py:61`, `testing/fitter_test_utils.py:24`, and the
+  re-export at `data_structures.py:27`).
+- Delete `MiniProtocol` and `MiniType` from `data_structures.py`.
+- Rewrite all 81 `FitResult[...]` annotations to plain `FitResult`:
+  `FitResult[MiniT]` (50), `FitResult[xr.DataTree]` (16), `FitResult[typing.Any]`
+  (10), `FitResult[Minimizer]` (8), `FitResult[Any]` (4),
+  `FitResult[odrpack.OdrResult]` (3). This spans `data_structures.py`,
+  `core.py`, `odr.py`, `bayes.py`, `plotting.py`, `titration.py`, `export.py`,
+  `__main__.py`, `testing/evaluation.py`, and `testing/fitter_test_utils.py`.
+
+Deleting `MiniT` also dissolves the import-cycle concern that put it in the
+leaf `clophfit_types` module in the first place — with the union gone, there is
+no cross-module alias to protect.
+
+`odrpack` / `xr` / `Minimizer` imports that existed only to build `MiniT` in
+`clophfit_types.py` are pruned if nothing else there uses them (ruff F401 is the
+arbiter). `data_structures.py` gains a `Minimizer` type-import and keeps its
+`xr` / `OdrResult` type-imports for the new field annotations.
+
+### 7. Bulk-edit strategy
+
+The 81 annotation rewrites are the bulk of the diff and are mechanical. Do them
+as a distinct step from the field/logic changes so the semantic changes (§1-§5)
+are reviewable in isolation from the mechanical churn (§6). `mypy` is the
+safety net: after the field split lands, every stale `FitResult[...]` is a type
+error, so the rewrite is complete exactly when `mypy` is clean.
+
+## Testing
+
+- **Regression:** the full suite (`uv run pytest tests/`) must stay green. This
+  is a behaviour-preserving refactor.
+- **Field routing (new):** an lmfit fit populates `.mini` and leaves
+  `.trace`/`.odr` `None`; an ODR fit populates `.odr` and leaves `.mini`/`.trace`
+  `None`; a PyMC fit populates `.trace` and leaves `.mini`/`.odr` `None`.
+- **`is_valid()` (new):** true for a PyMC fit (the case the split fixes),
+  true for lmfit and ODR, false for an empty `FitResult()`.
+- **Residuals unchanged:** `FitResult.residuals` for a classical fit is
+  identical before and after (the `mini`→`trace` swap is a no-op there);
+  for an MCMC fit `residual_likelihood` still resolves from the trace.
+- **`mypy`** clean across `src/clophfit` — the completeness check for §6.
+
+## Risks and limitations
+
+- **External callers of `.mini`.** A hard cut (no shim) means any downstream
+  code — notebooks, scripts — that read a trace or ODR result out of `.mini`
+  breaks until migrated. Accepted: all in-repo callers are migrated here, and
+  `prtecan_devel.ipynb` (out of scope, owner-owned) is the only known external
+  reader; its `.mini` uses, if any, are the owner's to update.
+- **Annotation churn size.** 81 edits is a large diff, but purely mechanical and
+  mypy-verified. Splitting the PR further (fields vs annotations) is possible
+  but the two are coupled through `mypy` — the annotations cannot compile until
+  the field lands, so they ship together, sequenced per §7.
+
+## Out of scope
+
+- `shared_floor` for the PyMC noise priors — its own spec and PR (Part B).
+- Any change to `MultiFitResult`, which already has a first-class `trace` field.
+- Folding `pymc_multi` or FGLS into `Titration.fit_plate` (recorded in the
+  plate-fit-residuals spec's follow-ups).
+- A deprecation shim on `.mini` — explicitly rejected in favour of a hard cut.

--- a/src/clophfit/__main__.py
+++ b/src/clophfit/__main__.py
@@ -49,7 +49,7 @@ from clophfit.prtecan import TecanConfig, Titration, calculate_conc
 from clophfit.prtecan.export import export_data_fit
 
 if TYPE_CHECKING:
-    from clophfit.fitting.data_structures import FitResult, MiniT
+    from clophfit.fitting.data_structures import FitResult
 
 
 class _FlexChoice(click.Choice):
@@ -574,7 +574,7 @@ def fit_enspire(  # noqa: C901,PLR0912
                         _print_result(spectra_gres.bands, pdf_file, bands_str)
 
 
-def _print_result(fit_result: FitResult[MiniT], pdf_file: Path, band_str: str) -> None:
+def _print_result(fit_result: FitResult, pdf_file: Path, band_str: str) -> None:
     print(str(pdf_file))
     print(f"Best fit using '{band_str}' band:\n")
     ci = lmfit.conf_interval(fit_result.mini, fit_result.result)

--- a/src/clophfit/clophfit_types.py
+++ b/src/clophfit/clophfit_types.py
@@ -3,21 +3,11 @@
 from collections.abc import Callable, Mapping
 
 import numpy as np
-import odrpack
-import xarray as xr
-from lmfit.minimizer import Minimizer  # type: ignore[import-untyped]
 from numpy.typing import NDArray
 
 # Array types
 ArrayF = NDArray[np.float64]  # Generic float64 array
 ArrayMask = NDArray[np.bool_]
-
-# Minimizer/backend result union shared across fitting modules.
-# Defined here (a dependency-light leaf module) rather than in
-# ``fitting.data_structures`` so it is never pulled into the fitting-package
-# import cycle, which would otherwise demote this implicit alias to a plain
-# variable in mypy's eyes (``MiniT is not valid as a type``).
-MiniT = Minimizer | odrpack.OdrResult | xr.DataTree
 
 # Dictionary types
 ArrayDict = dict[

--- a/src/clophfit/fitting/bayes.py
+++ b/src/clophfit/fitting/bayes.py
@@ -45,7 +45,6 @@ from .data_structures import (
     DataArray,
     Dataset,
     FitResult,
-    MiniT,
     MultiFitResult,
     NoiseModelParams,
     PlateNoiseModel,
@@ -501,7 +500,7 @@ def _fit_result_from_data_priors(  # noqa: PLR0913
     k_prior: DataKPrior,
     k_bounds: tuple[float, float] | None,
     k_sigma: float,
-) -> FitResult[xr.DataTree]:
+) -> FitResult:
     """Create an lmfit-like seed result using only data-derived priors."""
     params = Parameters()
     lo, hi = _resolve_data_prior_k_bounds(k_bounds, is_ph=ds.is_ph)
@@ -546,7 +545,7 @@ def _fit_result_from_data_priors(  # noqa: PLR0913
 
 
 def _normalize_fit_input(  # noqa: PLR0913
-    ds_or_fr: Dataset | FitResult[MiniT],
+    ds_or_fr: Dataset | FitResult,
     *,
     init_strategy: InitStrategy = "lmfit",
     data_prior_edge_points: int = 2,
@@ -554,12 +553,12 @@ def _normalize_fit_input(  # noqa: PLR0913
     data_prior_k_prior: DataKPrior = "midpoint_truncnorm",
     data_prior_k_bounds: tuple[float, float] | None = None,
     data_prior_k_sigma: float = 1.5,
-) -> tuple[FitResult[MiniT], bool]:
+) -> tuple[FitResult, bool]:
     """Normalize PyMC input to a copied preliminary fit result.
 
     Parameters
     ----------
-    ds_or_fr : Dataset | FitResult[MiniT]
+    ds_or_fr : Dataset | FitResult
         Either a raw dataset or a pre-fit result used to seed the Bayesian
         model.
     init_strategy : InitStrategy
@@ -579,7 +578,7 @@ def _normalize_fit_input(  # noqa: PLR0913
 
     Returns
     -------
-    tuple[FitResult[MiniT], bool]
+    tuple[FitResult, bool]
         The normalized fit result and whether the caller explicitly supplied a
         pre-fit ``FitResult``.
     """
@@ -588,16 +587,13 @@ def _normalize_fit_input(  # noqa: PLR0913
         if ds is None:
             return FitResult(), False
         return (
-            typing.cast(
-                "FitResult[MiniT]",
-                _fit_result_from_data_priors(
-                    ds,
-                    edge_points=data_prior_edge_points,
-                    signal_sigma_scale=data_prior_signal_sigma_scale,
-                    k_prior=data_prior_k_prior,
-                    k_bounds=data_prior_k_bounds,
-                    k_sigma=data_prior_k_sigma,
-                ),
+            _fit_result_from_data_priors(
+                ds,
+                edge_points=data_prior_edge_points,
+                signal_sigma_scale=data_prior_signal_sigma_scale,
+                k_prior=data_prior_k_prior,
+                k_bounds=data_prior_k_bounds,
+                k_sigma=data_prior_k_sigma,
             ),
             False,
         )
@@ -607,7 +603,7 @@ def _normalize_fit_input(  # noqa: PLR0913
 
 
 def _normalize_fit_inputs(  # noqa: PLR0913
-    results: Mapping[str, Dataset | FitResult[MiniT]],
+    results: Mapping[str, Dataset | FitResult],
     *,
     init_strategy: InitStrategy = "lmfit",
     data_prior_edge_points: int = 2,
@@ -615,12 +611,12 @@ def _normalize_fit_inputs(  # noqa: PLR0913
     data_prior_k_prior: DataKPrior = "midpoint_truncnorm",
     data_prior_k_bounds: tuple[float, float] | None = None,
     data_prior_k_sigma: float = 1.5,
-) -> tuple[dict[str, FitResult[MiniT]], bool]:
+) -> tuple[dict[str, FitResult], bool]:
     """Normalize multi-well PyMC inputs to copied preliminary fit results.
 
     Parameters
     ----------
-    results : Mapping[str, Dataset | FitResult[MiniT]]
+    results : Mapping[str, Dataset | FitResult]
         Per-well raw datasets or pre-fit results.
     init_strategy : InitStrategy
         ``"lmfit"`` fits each raw dataset with LMFit; ``"data_priors"`` seeds
@@ -641,28 +637,25 @@ def _normalize_fit_inputs(  # noqa: PLR0913
 
     Returns
     -------
-    tuple[dict[str, FitResult[MiniT]], bool]
+    tuple[dict[str, FitResult], bool]
         Normalized per-well fit results and whether the centered-noise defaults
         should be preferred (every input already a ``FitResult`` and not using
         the data-prior strategy).
     """
-    normalized: dict[str, FitResult[MiniT]] = {}
+    normalized: dict[str, FitResult] = {}
     all_prefit = True
     for key, value in results.items():
         if init_strategy == "data_priors":
             ds = value.dataset if isinstance(value, FitResult) else value
             if ds is None:
                 continue
-            normalized[key] = typing.cast(
-                "FitResult[MiniT]",
-                _fit_result_from_data_priors(
-                    ds,
-                    edge_points=data_prior_edge_points,
-                    signal_sigma_scale=data_prior_signal_sigma_scale,
-                    k_prior=data_prior_k_prior,
-                    k_bounds=data_prior_k_bounds,
-                    k_sigma=data_prior_k_sigma,
-                ),
+            normalized[key] = _fit_result_from_data_priors(
+                ds,
+                edge_points=data_prior_edge_points,
+                signal_sigma_scale=data_prior_signal_sigma_scale,
+                k_prior=data_prior_k_prior,
+                k_bounds=data_prior_k_bounds,
+                k_sigma=data_prior_k_sigma,
             )
             all_prefit = False
         elif isinstance(value, Dataset):
@@ -849,7 +842,7 @@ def _log_scaled_ye_mag_mu(
 
 
 def _masked_obs_err_matrices(
-    fit_results: Mapping[str, FitResult[MiniT]],
+    fit_results: Mapping[str, FitResult],
     wells_list: Sequence[str],
     lbl: str,
     n_steps: int,
@@ -858,7 +851,7 @@ def _masked_obs_err_matrices(
 
     Parameters
     ----------
-    fit_results : Mapping[str, FitResult[MiniT]]
+    fit_results : Mapping[str, FitResult]
         Per-well fit results whose ``.dataset`` supplies the arrays.
     wells_list : Sequence[str]
         Well keys in the order they appear as columns.
@@ -1413,10 +1406,10 @@ def _compute_weighted_residuals(ds: Dataset, rpars: Parameters) -> np.ndarray:
 class PymcResidualRefitResult:
     """Results from the robust residual-screening PyMC refit workflow."""
 
-    initial: FitResult[xr.DataTree]
+    initial: FitResult
     residuals: pd.DataFrame
     masked_dataset: Dataset
-    final: FitResult[xr.DataTree]
+    final: FitResult
 
 
 @dataclass
@@ -1505,7 +1498,7 @@ def _resolve_structured_noise_model(noise: NoiseConfig, ds: Dataset) -> PlateNoi
 
 def process_trace(
     trace: xr.DataTree, p_names: typing.Iterable[str], ds: Dataset
-) -> FitResult[xr.DataTree]:
+) -> FitResult:
     """Process the trace to extract parameter estimates and update datasets.
 
     Parameters
@@ -1519,7 +1512,7 @@ def process_trace(
 
     Returns
     -------
-    FitResult[xr.DataTree]
+    FitResult
         The updated fit result with extracted parameter values and datasets.
         Residuals are WEIGHTED (weight * (obs - pred)) where weight = 1/y_err,
         computed using posterior mean parameter estimates.
@@ -1564,7 +1557,7 @@ def extract_fit(  # noqa: PLR0913, C901, PLR0912
     *,
     raw_trace: xr.DataTree | None = None,
     global_p_names: typing.Iterable[str] = (),
-) -> FitResult[xr.DataTree]:
+) -> FitResult:
     """Compute individual dataset fit from a multi-well trace summary.
 
     Parameters
@@ -1592,7 +1585,7 @@ def extract_fit(  # noqa: PLR0913, C901, PLR0912
 
     Returns
     -------
-    FitResult[xr.DataTree]
+    FitResult
         Fit result with figure, parameters, and dataset using posterior x.
     """
     trace_obj = trace_df.trace if isinstance(trace_df, MultiFitResult) else trace_df
@@ -1933,15 +1926,15 @@ def _update_dataset_yerr_from_sigma_obs(  # noqa: C901, PLR0912
 
 def _per_well_fit_results_from_trace(
     trace: xr.DataTree,
-    fit_results: Mapping[str, FitResult[MiniT]],
+    fit_results: Mapping[str, FitResult],
     scheme: PlateScheme,
     *,
     x_error_model: Literal["deterministic", "per_well"],
     global_p_names: typing.Iterable[str] = (),
-) -> dict[str, FitResult[xr.DataTree]]:
+) -> dict[str, FitResult]:
     """Reconstruct per-well fit results from a shared multi-well trace."""
     trace_df = _trace_summary_df(trace)
-    per_well_results: dict[str, FitResult[xr.DataTree]] = {}
+    per_well_results: dict[str, FitResult] = {}
     for key, fr in fit_results.items():
         if fr.dataset is None:
             continue
@@ -1968,7 +1961,7 @@ _DEFAULT_SAMPLER = SamplerConfig()
 
 
 def fit_binding_pymc(  # noqa: PLR0913, PLR0915
-    ds_or_fr: Dataset | FitResult[MiniT],
+    ds_or_fr: Dataset | FitResult,
     *,
     n_sd: float = 10.0,
     n_xerr: float = 1.0,
@@ -1977,12 +1970,12 @@ def fit_binding_pymc(  # noqa: PLR0913, PLR0915
     robust: RobustConfig = _DEFAULT_ROBUST,
     init: InitConfig = _DEFAULT_INIT,
     sampler: SamplerConfig = _DEFAULT_SAMPLER,
-) -> FitResult[xr.DataTree]:
+) -> FitResult:
     """Analyze multi-label titration datasets using PyMC (single model).
 
     Parameters
     ----------
-    ds_or_fr : Dataset | FitResult[MiniT]
+    ds_or_fr : Dataset | FitResult
         Either a ``Dataset`` (an initial LS fit is run) or a ``FitResult`` whose
         params seed the PyMC priors.
     n_sd : float
@@ -2007,7 +2000,7 @@ def fit_binding_pymc(  # noqa: PLR0913, PLR0915
 
     Returns
     -------
-    FitResult[xr.DataTree]
+    FitResult
         Bayesian fitting results.
     """
     robust_on = robust.enabled
@@ -2317,7 +2310,7 @@ def fit_binding_pymc_residual_refit(  # noqa: PLR0913
         min_allowed_tail_count=min_allowed_tail_count,
     )
     mask_source = initial.dataset if initial.dataset is not None else ds
-    holder = FitResult[xr.DataTree](dataset=copy.deepcopy(mask_source))
+    holder = FitResult(dataset=copy.deepcopy(mask_source))
     masked = model_validation.masked_datasets_from_residual_outliers(
         {"single": holder},
         residuals,
@@ -2351,7 +2344,7 @@ def fit_binding_pymc_residual_refit(  # noqa: PLR0913
 
 
 def fit_binding_pymc_multi_residual_refit(  # noqa: C901, PLR0912, PLR0913
-    results: Mapping[str, Dataset | FitResult[MiniT]],
+    results: Mapping[str, Dataset | FitResult],
     scheme: PlateScheme,
     *,
     noise_strategy: Literal["proportional", "ye_mag"] = "proportional",
@@ -2389,7 +2382,7 @@ def fit_binding_pymc_multi_residual_refit(  # noqa: C901, PLR0912, PLR0913
 
     Parameters
     ----------
-    results : Mapping[str, Dataset | FitResult[MiniT]]
+    results : Mapping[str, Dataset | FitResult]
         Per-well datasets or prefit results used as inputs to the screening
         pass.
     scheme : PlateScheme
@@ -2478,7 +2471,7 @@ def fit_binding_pymc_multi_residual_refit(  # noqa: C901, PLR0912, PLR0913
             )
         else:
             proportional_noise_model = noise_model
-        initial_inputs: Mapping[str, Dataset | FitResult[MiniT]] = results
+        initial_inputs: Mapping[str, Dataset | FitResult] = results
         noise_cfg = NoiseConfig.structured(
             noise_model=proportional_noise_model,
             floor_mode="centered",
@@ -2488,7 +2481,7 @@ def fit_binding_pymc_multi_residual_refit(  # noqa: C901, PLR0912, PLR0913
             shared_gain=False,
         )
     else:
-        unit_inputs: dict[str, Dataset | FitResult[MiniT]] = {}
+        unit_inputs: dict[str, Dataset | FitResult] = {}
         for key, item in results.items():
             if isinstance(item, FitResult):
                 copied = copy.deepcopy(item)
@@ -2536,7 +2529,7 @@ def fit_binding_pymc_multi_residual_refit(  # noqa: C901, PLR0912, PLR0913
         allowed_tail_fraction=allowed_tail_fraction,
         min_allowed_tail_count=min_allowed_tail_count,
     )
-    initial_holders: dict[str, FitResult[xr.DataTree]] = {}
+    initial_holders: dict[str, FitResult] = {}
     for well, item in initial_inputs.items():
         if isinstance(item, FitResult):
             dataset = copy.deepcopy(item.dataset) if item.dataset is not None else None
@@ -2548,7 +2541,7 @@ def fit_binding_pymc_multi_residual_refit(  # noqa: C901, PLR0912, PLR0913
         residuals,
         min_keep=min_keep,
     )
-    final_inputs: dict[str, FitResult[xr.DataTree]] = {}
+    final_inputs: dict[str, FitResult] = {}
     for well, fit in initial.results.items():
         copied = copy.deepcopy(fit)
         if str(well) in masked:
@@ -2690,7 +2683,7 @@ def _build_ctr_k_params(  # noqa: PLR0913
 
 
 def _free_k_init(  # noqa: PLR0913
-    fit_results: dict[str, FitResult[MiniT]],
+    fit_results: dict[str, FitResult],
     wells_list: list[str],
     scheme: PlateScheme,
     ctr_ks: dict[str, tuple[float, float]],
@@ -2714,7 +2707,7 @@ def _free_k_init(  # noqa: PLR0913
 
     Parameters
     ----------
-    fit_results : dict[str, FitResult[MiniT]]
+    fit_results : dict[str, FitResult]
         Per-well preliminary fit results.
     wells_list : list[str]
         Ordered active well keys.
@@ -2827,7 +2820,7 @@ def _ph_at_mid_fluorescence(da: DataArray) -> float | None:
 
 
 def _well_k_init_from_results(
-    results: dict[str, FitResult[MiniT]],
+    results: dict[str, FitResult],
     scheme: PlateScheme,
     n_sd: float,
     fallback_sigma: float = 0.6,
@@ -2842,7 +2835,7 @@ def _well_k_init_from_results(
 
     Parameters
     ----------
-    results : dict[str, FitResult[MiniT]]
+    results : dict[str, FitResult]
         Preliminary fit results keyed by well name.
     scheme : PlateScheme
         Plate scheme; only wells listed in ``scheme.names`` are processed.
@@ -2897,7 +2890,7 @@ def _well_k_init_from_results(
 
 
 def fit_binding_pymc_multi(  # noqa: C901, PLR0912, PLR0913, PLR0915
-    results: Mapping[str, Dataset | FitResult[MiniT]],
+    results: Mapping[str, Dataset | FitResult],
     scheme: PlateScheme,
     *,
     n_sd: float = 5.0,
@@ -2922,7 +2915,7 @@ def fit_binding_pymc_multi(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
     Parameters
     ----------
-    results : Mapping[str, Dataset | FitResult[MiniT]]
+    results : Mapping[str, Dataset | FitResult]
         Per-well datasets or initial fit results. Raw datasets are first fitted
         with :func:`fit_binding_glob` to seed the Bayesian model.
     scheme : PlateScheme

--- a/src/clophfit/fitting/bayes.py
+++ b/src/clophfit/fitting/bayes.py
@@ -1552,7 +1552,7 @@ def process_trace(
     plot_fit(ax, ds, rpars, nboot=N_BOOT, pp=PlotParameters(ds.is_ph))
 
     residuals = _compute_weighted_residuals(ds, rpars)
-    return FitResult(fig, _Result(rpars, residual=residuals), trace, ds)
+    return FitResult(fig, _Result(rpars, residual=residuals), trace=trace, dataset=ds)
 
 
 def extract_fit(  # noqa: PLR0913, C901, PLR0912
@@ -1647,8 +1647,8 @@ def extract_fit(  # noqa: PLR0913, C901, PLR0912
     ax = fig.add_subplot(111)
     plot_fit(ax, ds, rpars, nboot=N_BOOT, pp=PlotParameters(ds.is_ph))
     residuals = _compute_weighted_residuals(ds, rpars)
-    mini = trace_obj if isinstance(trace_obj, xr.DataTree) else xr.DataTree()
-    return FitResult(fig, _Result(rpars, residual=residuals), mini, ds)
+    trace = trace_obj if isinstance(trace_obj, xr.DataTree) else xr.DataTree()
+    return FitResult(fig, _Result(rpars, residual=residuals), trace=trace, dataset=ds)
 
 
 def _extract_x_true_from_trace_df(
@@ -1957,7 +1957,7 @@ def _per_well_fit_results_from_trace(
             raw_trace=trace,
             global_p_names=global_p_names,
         )
-        per_well_results[key].mini = trace
+        per_well_results[key].trace = trace
     return per_well_results
 
 

--- a/src/clophfit/fitting/core.py
+++ b/src/clophfit/fitting/core.py
@@ -214,7 +214,7 @@ def weight_multi_ds_titration(ds: Dataset) -> None:
 
 def analyze_spectra(
     spectra: pd.DataFrame, *, is_ph: bool, band: tuple[int, int] | None = None
-) -> FitResult[Minimizer]:
+) -> FitResult:
     """Analyze spectra titration, fit the data, and plot the results.
 
     This function performs either Singular Value Decomposition (SVD) or
@@ -231,7 +231,7 @@ def analyze_spectra(
 
     Returns
     -------
-    FitResult[Minimizer]
+    FitResult
         An object containing the fit results and the summary plot.
 
     Raises
@@ -328,7 +328,7 @@ def analyze_spectra_glob(
 def _plot_spectra_glob_emcee(
     titration: dict[str, pd.DataFrame],
     ds: Dataset,
-    f_res: FitResult[Minimizer],
+    f_res: FitResult,
     dbands: dict[str, tuple[int, int]] | None = None,
 ) -> figure.Figure:
     fig, (ax1, ax2, ax3, ax4, ax5) = _create_spectra_canvas()
@@ -365,7 +365,7 @@ def fit_binding_glob(  # noqa: PLR0913
     max_iter: int = 15,
     tol: float = 0.01,
     scale_covar: bool = True,
-) -> FitResult[Minimizer]:
+) -> FitResult:
     r"""Analyze multi-label titration datasets and visualize the results.
 
     Unified fitting function that supports standard least-squares and robust
@@ -400,7 +400,7 @@ def fit_binding_glob(  # noqa: PLR0913
 
     Returns
     -------
-    FitResult[Minimizer]
+    FitResult
         An object containing the fit results, plot figure, minimizer, and
         dataset copy.
 

--- a/src/clophfit/fitting/core.py
+++ b/src/clophfit/fitting/core.py
@@ -282,7 +282,7 @@ def analyze_spectra(
     fit_params = result.params if result else Parameters()
     plot_fit(ax4, ds, fit_params, nboot=N_BOOT, pp=PlotParameters(is_ph))
     ax4.set_ylabel(ylabel, color=ylabel_color)
-    return FitResult(fig, result, mini, ds)
+    return FitResult(fig, result, mini=mini, dataset=ds)
 
 
 def analyze_spectra_glob(
@@ -309,7 +309,7 @@ def analyze_spectra_glob(
         weight_multi_ds_titration(ds_svd)
         f_res = fit_binding_glob(ds_svd)
         fig = _plot_spectra_glob_emcee(titration, ds_svd, f_res)
-        gsvd = FitResult(fig, f_res.result, f_res.mini)
+        gsvd = FitResult(fig, f_res.result, mini=f_res.mini)
     else:
         svd, gsvd = None, None
 
@@ -318,7 +318,7 @@ def analyze_spectra_glob(
         weight_multi_ds_titration(ds_bands)
         f_res = fit_binding_glob(ds_bands)
         fig = _plot_spectra_glob_emcee(titration, ds_bands, f_res, dbands)
-        bands = FitResult(fig, f_res.result, f_res.mini)
+        bands = FitResult(fig, f_res.result, mini=f_res.mini)
     else:
         bands = None
 
@@ -490,7 +490,7 @@ def fit_binding_glob(  # noqa: PLR0913
     plot_fit(
         ax, ds_working, fit_params, nboot=N_BOOT, pp=PlotParameters(ds_working.is_ph)
     )
-    return FitResult(fig, result, mini, copy.deepcopy(ds_working))
+    return FitResult(fig, result, mini=mini, dataset=copy.deepcopy(ds_working))
 
 
 # ---- Legacy helper ----

--- a/src/clophfit/fitting/data_structures.py
+++ b/src/clophfit/fitting/data_structures.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     )
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
+    from odrpack import OdrResult
 
     from clophfit.clophfit_types import ArrayF, ArrayMask
 
@@ -577,8 +578,13 @@ class FitResult[MiniType: MiniProtocol](ResidualsMixin):
     residual, redchi, and success fields (as in lmfit). For lmfit this is a
     MinimizerResult."""
     mini: MiniType | None = None
-    """The primary backend object (e.g., lmfit.Minimizer, odrpack.Output, or
-    xr.DataTree for PyMC)."""
+    """The lmfit ``Minimizer`` object (for ``conf_interval``, ``emcee``,
+    ``userargs``). ``None`` for non-lmfit backends."""
+    trace: xr.DataTree | None = None
+    """The PyMC posterior trace. ``None`` for non-PyMC backends."""
+    odr: OdrResult | None = None
+    """The odrpack output (``res_var``, outlier detection). ``None`` for
+    non-ODR backends."""
     dataset: Dataset | None = None
     """Dataset used for the fit (typically a deep copy of the input dataset)."""
 
@@ -595,11 +601,13 @@ class FitResult[MiniType: MiniProtocol](ResidualsMixin):
         return f"K = {k_val:.3g} (no uncertainty available)"
 
     def is_valid(self) -> bool:
-        """Whether figure, result, and minimizer exist."""
+        """Whether a figure, a result, and at least one backend object exist."""
         return (
             self.figure is not None
             and self.result is not None
-            and self.mini is not None
+            and (
+                self.mini is not None or self.trace is not None or self.odr is not None
+            )
         )
 
     def residual_table(
@@ -634,7 +642,7 @@ class FitResult[MiniType: MiniProtocol](ResidualsMixin):
             The canonical residual table (see :attr:`residuals`).
         """
         settings = self._resolve_residual_settings(
-            self.mini,
+            self.trace,
             binding_function=binding_function,
             robust=robust,
             student_t_nu=student_t_nu,
@@ -646,7 +654,7 @@ class FitResult[MiniType: MiniProtocol](ResidualsMixin):
             robust=settings.robust,
             student_t_nu=settings.student_t_nu,
             outlier_threshold=outlier_threshold,
-            trace=self.mini,
+            trace=self.trace,
             residual_likelihood=settings.residual_likelihood,
         )
 

--- a/src/clophfit/fitting/data_structures.py
+++ b/src/clophfit/fitting/data_structures.py
@@ -15,16 +15,13 @@ from collections import UserDict
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple, Protocol, TypeVar, cast, runtime_checkable
+from typing import TYPE_CHECKING, NamedTuple, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from uncertainties import ufloat  # type: ignore[import-untyped]
 
-# Re-exported for back-compat: MiniT lives in the leaf ``clophfit_types`` module
-# so it stays out of the fitting-package import cycle (see its definition there).
-from clophfit.clophfit_types import MiniT as MiniT  # noqa: PLC0414
 from clophfit.fitting.model_validation import (
     STUDENT_T_NU,
     residuals_from_fit_results,
@@ -487,14 +484,6 @@ class _Result:
     success: bool = True
 
 
-@runtime_checkable
-class MiniProtocol(Protocol):
-    """A very small common interface for all minimizers / backends."""
-
-
-MiniType = TypeVar("MiniType", bound=MiniProtocol)
-
-
 class _ResidualSettings(NamedTuple):
     """Resolved settings for building a canonical residual table."""
 
@@ -568,7 +557,7 @@ class ResidualsMixin:
 
 
 @dataclass
-class FitResult[MiniType: MiniProtocol](ResidualsMixin):
+class FitResult(ResidualsMixin):
     """Result container of a fitting procedure."""
 
     figure: Figure | None = None
@@ -577,7 +566,7 @@ class FitResult[MiniType: MiniProtocol](ResidualsMixin):
     """Backend-agnostic fit result exposing a .params attribute along with
     residual, redchi, and success fields (as in lmfit). For lmfit this is a
     MinimizerResult."""
-    mini: MiniType | None = None
+    mini: Minimizer | None = None
     """The lmfit ``Minimizer`` object (for ``conf_interval``, ``emcee``,
     ``userargs``). ``None`` for non-lmfit backends."""
     trace: xr.DataTree | None = None
@@ -667,12 +656,12 @@ class MultiFitResult(ResidualsMixin):
     ----------
     trace : xr.DataTree
         Shared PyMC trace from the multi-well fit.
-    results : dict[str, FitResult[xr.DataTree]]
+    results : dict[str, FitResult]
         Per-well fit results reconstructed from the shared trace.
     """
 
     trace: xr.DataTree
-    results: dict[str, FitResult[xr.DataTree]]
+    results: dict[str, FitResult]
 
     def __getattr__(self, name: str) -> object:
         """Delegate trace attributes for convenient compatibility."""
@@ -725,13 +714,13 @@ class MultiFitResult(ResidualsMixin):
 class SpectraGlobResults:
     """A dataclass representing the results of both svd and bands fits."""
 
-    svd: FitResult[Minimizer] | None = field(default=None)
+    svd: FitResult | None = field(default=None)
     """The `FitResult` object representing the outcome of the concatenated svd
     fit, or `None` if the svd fit was not performed."""
-    gsvd: FitResult[Minimizer] | None = field(default=None)
+    gsvd: FitResult | None = field(default=None)
     """The `FitResult` object representing the outcome of the global svd fit,
     or `None` if the svd fit was not performed."""
-    bands: FitResult[Minimizer] | None = field(default=None)
+    bands: FitResult | None = field(default=None)
     """The `FitResult` object representing the outcome of the bands fit, or
     `None` if the bands fit was not performed."""
 

--- a/src/clophfit/fitting/model_validation.py
+++ b/src/clophfit/fitting/model_validation.py
@@ -1023,9 +1023,7 @@ def trace_parameter_summary(results: _t.Mapping[str, _t.Any]) -> pd.DataFrame:
     """
     rows: list[dict[str, _t.Any]] = []
     for well, fit in results.items():
-        trace = getattr(fit, "mini", None)
-        if trace is None:
-            trace = getattr(fit, "trace", None)
+        trace = getattr(fit, "trace", None)
         if trace is None:
             continue
         posterior = _posterior_dataset_or_none(trace)

--- a/src/clophfit/fitting/odr.py
+++ b/src/clophfit/fitting/odr.py
@@ -215,7 +215,10 @@ def fit_binding_odr(  # noqa: C901, PLR0915
         ax = fig.add_subplot(111)
         plot_fit(ax, ds, params, nboot=20, pp=PlotParameters(ds.is_ph))
         return FitResult(
-            fig, _Result(params, residual=residuals, redchi=output.res_var), output, ds
+            fig,
+            _Result(params, residual=residuals, redchi=output.res_var),
+            odr=output,
+            dataset=ds,
         )
 
     # Initial fit
@@ -230,31 +233,31 @@ def fit_binding_odr(  # noqa: C901, PLR0915
     if remove_outliers:
         _method, threshold, _min_keep = parse_remove_outliers(remove_outliers)
 
-    residual_variance = ro.mini.res_var if ro.mini else 0.0
+    residual_variance = ro.odr.res_var if ro.odr else 0.0
 
     for _ in range(max_iter):
-        if remove_outliers and ro.mini:
-            omask = outlier(ro.mini, threshold=threshold)
+        if remove_outliers and ro.odr:
+            omask = outlier(ro.odr, threshold=threshold)
             if omask.any() and ro.dataset:
                 # Apply mask to the starting FitResult's dataset to exclude points
                 fr.dataset.apply_mask(~omask)
 
         rn = _single_odr_fit(fr)
-        if rn.mini and rn.mini.res_var == 0:
+        if rn.odr and rn.odr.res_var == 0:
             rn = ro
             break
 
-        if rn.mini and residual_variance - rn.mini.res_var < tol:
+        if rn.odr and residual_variance - rn.odr.res_var < tol:
             if not remove_outliers:
                 break
             # If removing outliers, also require no new outliers to converge
             if remove_outliers:
-                omask_new = outlier(rn.mini, threshold=threshold)
+                omask_new = outlier(rn.odr, threshold=threshold)
                 if not omask_new.any():
                     ro = rn
                     break
 
-        residual_variance = rn.mini.res_var if rn.mini else 0.0
+        residual_variance = rn.odr.res_var if rn.odr else 0.0
         ro = rn
         fr = copy.deepcopy(ro)  # update starting point for next iteration
 

--- a/src/clophfit/fitting/odr.py
+++ b/src/clophfit/fitting/odr.py
@@ -17,7 +17,7 @@ from clophfit.fitting.utils import identify_outliers_zscore, parse_remove_outlie
 from clophfit.utils import weights_from_sigma
 
 from .core import fit_binding_glob
-from .data_structures import Dataset, FitResult, MiniT, _Result
+from .data_structures import Dataset, FitResult, _Result
 
 if typing.TYPE_CHECKING:
     from clophfit.clophfit_types import ArrayF, ArrayMask
@@ -115,18 +115,18 @@ def generalized_combined_model(
 
 
 def fit_binding_odr(  # noqa: C901, PLR0915
-    ds_or_fr: Dataset | FitResult[MiniT],
+    ds_or_fr: Dataset | FitResult,
     *,
     reweight: bool = False,
     remove_outliers: str | None = None,
     max_iter: int = 15,
     tol: float = 0.1,
-) -> FitResult[odrpack.OdrResult]:
+) -> FitResult:
     """Analyze multi-label titration datasets using ODR.
 
     Parameters
     ----------
-    ds_or_fr : Dataset | FitResult[MiniT]
+    ds_or_fr : Dataset | FitResult
         Either a Dataset (will run initial LS fit) or a FitResult with initial params.
     reweight : bool
         Whether to perform iterative reweighting (recursive ODR).
@@ -140,7 +140,7 @@ def fit_binding_odr(  # noqa: C901, PLR0915
 
     Returns
     -------
-    FitResult[odrpack.OdrResult]
+    FitResult
         ODR fitting results. Residuals are WEIGHTED by the ORIGINAL y_err
         (before ODR modified it), making them comparable to LM residuals.
     """
@@ -154,7 +154,7 @@ def fit_binding_odr(  # noqa: C901, PLR0915
     if fr.result is None or fr.dataset is None:
         return FitResult()
 
-    def _single_odr_fit(current_fr: FitResult[MiniT]) -> FitResult[odrpack.OdrResult]:
+    def _single_odr_fit(current_fr: FitResult) -> FitResult:
         if current_fr.result is None or current_fr.dataset is None:
             return FitResult()
         params = current_fr.result.params

--- a/src/clophfit/fitting/pipeline.py
+++ b/src/clophfit/fitting/pipeline.py
@@ -1,7 +1,6 @@
 """Pipeline orchestrators for fitting multistage workflows (e.g., FGLS)."""
 
 import logging
-import typing
 
 import pandas as pd
 
@@ -124,7 +123,7 @@ def fgls_plate_fit(  # noqa: PLR0913
     second_pass_method: str = "lm",  # noqa: S107
     max_iter: int = 3,
     tol: float = 1e-3,
-) -> tuple[dict[str, FitResult[typing.Any]], PlateNoiseModel]:
+) -> tuple[dict[str, FitResult], PlateNoiseModel]:
     """Run iterative Feasible Generalized Least Squares (FGLS) on a plate.
 
     1. First-pass fit (robust) on each well with existing ``y_errc``.
@@ -150,12 +149,12 @@ def fgls_plate_fit(  # noqa: PLR0913
 
     Returns
     -------
-    tuple[dict[str, FitResult[typing.Any]], PlateNoiseModel]
+    tuple[dict[str, FitResult], PlateNoiseModel]
         Final fit results keyed by well, and the converged (or last)
         calibrated noise model.
     """
     noise_model: PlateNoiseModel | None = None
-    results: dict[str, FitResult[typing.Any]] = {}
+    results: dict[str, FitResult] = {}
 
     for iteration in range(max_iter):
         # Choose method

--- a/src/clophfit/fitting/plotting.py
+++ b/src/clophfit/fitting/plotting.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
     from clophfit.clophfit_types import ArrayF
-    from clophfit.fitting.data_structures import FitResult, MiniT
+    from clophfit.fitting.data_structures import FitResult
 
     from .data_structures import Dataset
 
@@ -659,7 +659,7 @@ def plot_spectra_distributed(
 
 def plot_qc_mean_vs_std(  # noqa: PLR0913, PLR0917
     trace: xr.DataTree | MultiFitResult,
-    results: Mapping[str, FitResult[MiniT]] | None = None,
+    results: Mapping[str, FitResult] | None = None,
     figsize_per_label: tuple[float, float] = (5, 4),
     annotate_wells: list[str] | None = None,
     z_threshold: float = 3.0,
@@ -677,7 +677,7 @@ def plot_qc_mean_vs_std(  # noqa: PLR0913, PLR0917
     trace : xr.DataTree | MultiFitResult
         The PyMC inference trace containing `sigma_obs` deterministic nodes, or
         the multi-well result wrapper returned by ``fit_binding_pymc_multi``.
-    results : Mapping[str, FitResult[MiniT]] | None, optional
+    results : Mapping[str, FitResult] | None, optional
         The dictionary of well results to derive fallback sigma values.
     figsize_per_label : tuple[float, float], optional
         Figure size allocated for each spectral band (label). Default is (5, 4).
@@ -1139,7 +1139,7 @@ def _summary_stats_from_scalar_var(
 
 def _extract_sigma_df(
     trace: xr.DataTree | MultiFitResult,
-    results: Mapping[str, FitResult[MiniT]] | None = None,
+    results: Mapping[str, FitResult] | None = None,
 ) -> pd.DataFrame:
     """Extract heteroscedastic sigma_obs parameters from a PyMC trace into a DataFrame."""
     if isinstance(trace, MultiFitResult):
@@ -1181,7 +1181,7 @@ def _extract_sigma_df(
 
 def extract_sigma_df(
     trace: xr.DataTree | MultiFitResult,
-    results: Mapping[str, FitResult[MiniT]] | None = None,
+    results: Mapping[str, FitResult] | None = None,
 ) -> pd.DataFrame:
     """Extract heteroscedastic sigma summaries from a PyMC trace."""
     return _extract_sigma_df(trace, results)
@@ -1189,7 +1189,7 @@ def extract_sigma_df(
 
 def plot_noise_vs_index(
     trace: xr.DataTree | MultiFitResult,
-    results: Mapping[str, FitResult[MiniT]] | None = None,
+    results: Mapping[str, FitResult] | None = None,
     wells: Sequence[str] | str | None = None,
     figsize_per_well: tuple[float, float] = (5, 4),
     max_cols: int = 4,
@@ -1201,7 +1201,7 @@ def plot_noise_vs_index(
     trace : xr.DataTree | MultiFitResult
         The PyMC inference trace containing `sigma_obs` deterministic nodes, or
         the multi-well result wrapper returned by ``fit_binding_pymc_multi``.
-    results : Mapping[str, FitResult[MiniT]] | None, optional
+    results : Mapping[str, FitResult] | None, optional
         The dictionary of well results to derive fallback sigma values.
     wells : Sequence[str] | str | None, optional
         A specific well ID (e.g., 'A01'), a list of well IDs, or None to plot all
@@ -1273,7 +1273,7 @@ def plot_noise_vs_index(
 
 def plot_noise_vs_signal(
     trace: xr.DataTree | MultiFitResult,
-    results: Mapping[str, FitResult[MiniT]],
+    results: Mapping[str, FitResult],
     figsize_per_label: tuple[float, float] = (6, 5),
 ) -> Figure:
     """Plot inferred noise (sigma) versus observed signal across all wells.
@@ -1287,7 +1287,7 @@ def plot_noise_vs_signal(
     trace : xr.DataTree | MultiFitResult
         The PyMC inference trace containing the `sigma_obs` deterministic nodes,
         or the multi-well result wrapper returned by ``fit_binding_pymc_multi``.
-    results : Mapping[str, FitResult[MiniT]]
+    results : Mapping[str, FitResult]
         The dictionary of well results containing datasets with `.y` arrays.
         Normally this is `tit.result_global.results`.
     figsize_per_label : tuple[float, float], optional

--- a/src/clophfit/fitting/residuals.py
+++ b/src/clophfit/fitting/residuals.py
@@ -83,12 +83,12 @@ class ResidualPoint:
     raw_i: int
 
 
-def extract_residual_points(fr: FitResult[Any]) -> list[ResidualPoint]:
+def extract_residual_points(fr: FitResult) -> list[ResidualPoint]:
     """Extract residual points from a fit result.
 
     Parameters
     ----------
-    fr : FitResult[Any]
+    fr : FitResult
         Fit result containing residuals and dataset
 
     Returns
@@ -172,12 +172,12 @@ def extract_residual_points(fr: FitResult[Any]) -> list[ResidualPoint]:
     return pts
 
 
-def residual_dataframe(fr: FitResult[Any]) -> pd.DataFrame:
+def residual_dataframe(fr: FitResult) -> pd.DataFrame:
     """Convert fit result residuals to a DataFrame.
 
     Parameters
     ----------
-    fr : FitResult[Any]
+    fr : FitResult
         Fit result to extract residuals from
 
     Returns

--- a/src/clophfit/prtecan/export.py
+++ b/src/clophfit/prtecan/export.py
@@ -65,7 +65,7 @@ def prepare_output_folder(titration: Titration, base_path: Path) -> Path:
 
 
 def export_residuals(
-    outfit: Path, fit_results: dict[str, FitResult[typing.Any]], index: int
+    outfit: Path, fit_results: dict[str, FitResult], index: int
 ) -> None:
     """Export fit residuals and their statistics to files."""
     try:

--- a/src/clophfit/prtecan/titration.py
+++ b/src/clophfit/prtecan/titration.py
@@ -68,7 +68,7 @@ def _fit_datasets(
     datasets: dict[str, Dataset],
     method: str,
     **kwargs: typing.Any,  # noqa: ANN401
-) -> dict[str, FitResult[typing.Any]]:
+) -> dict[str, FitResult]:
     """Fit each dataset, turning per-well failures into empty results.
 
     Parameters
@@ -83,10 +83,10 @@ def _fit_datasets(
 
     Returns
     -------
-    dict[str, FitResult[typing.Any]]
+    dict[str, FitResult]
         One entry per input well; failed wells hold an empty `FitResult`.
     """
-    fitter: Callable[..., FitResult[typing.Any]]
+    fitter: Callable[..., FitResult]
     if method == "odr":
         fitter, fit_kind = fit_binding_odr, "ODR fit"
     elif method == "mcmc":
@@ -96,7 +96,7 @@ def _fit_datasets(
         fitter = functools.partial(fit_binding_glob, method=method)
         fit_kind = "fit"
 
-    results: dict[str, FitResult[typing.Any]] = {}
+    results: dict[str, FitResult] = {}
     for well, ds in datasets.items():
         try:
             results[well] = fitter(ds, **kwargs)
@@ -479,7 +479,7 @@ class TitrationResults(ResidualsMixin):
 
     scheme: PlateScheme = field(default_factory=PlateScheme)
     fit_keys: set[str] = field(default_factory=set)
-    results: dict[str, FitResult[typing.Any]] = field(default_factory=dict)
+    results: dict[str, FitResult] = field(default_factory=dict)
     _dataframe: pd.DataFrame = field(default_factory=pd.DataFrame)
     titration: InitVar[Titration | None] = None
 
@@ -565,7 +565,7 @@ class TitrationResults(ResidualsMixin):
         """Get or lazily compute a result for a given key."""
         return repr(self.results)
 
-    def __getitem__(self, key: str) -> FitResult[typing.Any]:
+    def __getitem__(self, key: str) -> FitResult:
         """Fetch result for a single key."""
         return self.results[key]
 

--- a/src/clophfit/testing/evaluation.py
+++ b/src/clophfit/testing/evaluation.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from clophfit.clophfit_types import ArrayF
-    from clophfit.fitting.data_structures import FitResult, MiniT
+    from clophfit.fitting.data_structures import FitResult
 
 SIGNIFICANCE_LEVEL = 0.05
 
@@ -138,12 +138,12 @@ def evaluate_residuals(residuals: np.ndarray) -> dict[str, float]:
     }
 
 
-def extract_params(fr: FitResult[MiniT], param_name: str = "K") -> tuple[float, float]:
+def extract_params(fr: FitResult, param_name: str = "K") -> tuple[float, float]:
     """Extract parameter value and error from a FitResult.
 
     Parameters
     ----------
-    fr : FitResult[MiniT]
+    fr : FitResult
         The fit result object.
     param_name : str
         The name of the parameter to extract (default: "K").

--- a/src/clophfit/testing/fitter_test_utils.py
+++ b/src/clophfit/testing/fitter_test_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from itertools import product
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
@@ -21,7 +21,7 @@ from clophfit.testing.synthetic import TruthParams, make_simple_dataset
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from clophfit.fitting.data_structures import Dataset, FitResult, MiniT
+    from clophfit.fitting.data_structures import Dataset, FitResult
 
 
 # Re-export for backwards compatibility
@@ -60,7 +60,7 @@ def _fit_binding_glob_for_method(
     method: TecanFitMethod,
     *,
     remove_outliers: str | None = None,
-) -> FitResult[MiniT]:
+) -> FitResult:
     """Run the global fitter with the configured robustification mode."""
     method_map: dict[TecanFitMethod, tuple[str, str | None]] = {
         "lm": ("lm", None),
@@ -193,9 +193,7 @@ def build_tecan_fit_combinations(
     return combinations
 
 
-def apply_tecan_combination(
-    ds: Dataset, combination: TecanFitCombination
-) -> FitResult[MiniT]:
+def apply_tecan_combination(ds: Dataset, combination: TecanFitCombination) -> FitResult:
     """Execute one Tecan fit combination on a fresh dataset copy."""
     work_ds = ds.copy(keys=list(combination.channels))
     if combination.weighting == "auto":
@@ -227,7 +225,7 @@ def apply_tecan_combination(
             remove_outliers=combination.outlier_handling,
         )
     if final_stage == "odr":
-        return cast("FitResult[MiniT]", fit_binding_odr(prefit_result))
+        return fit_binding_odr(prefit_result)
     if final_stage == "mcmc_single":
         return fit_binding_pymc(
             prefit_result,
@@ -242,7 +240,7 @@ def apply_tecan_combination(
     raise NotImplementedError(msg)
 
 
-def k_from_result(fr: FitResult[MiniT]) -> tuple[float | None, float | None]:
+def k_from_result(fr: FitResult) -> tuple[float | None, float | None]:
     """Extract K value and stderr from fit result."""
     if fr.result is None or not hasattr(fr.result, "params"):
         return None, None
@@ -252,7 +250,7 @@ def k_from_result(fr: FitResult[MiniT]) -> tuple[float | None, float | None]:
     return (float(k) if k is not None else None, float(sk) if sk is not None else None)
 
 
-def s_from_result(fr: FitResult[MiniT], which: str) -> dict[str, float] | None:
+def s_from_result(fr: FitResult, which: str) -> dict[str, float] | None:
     """Extract S0 or S1 values per label if present in params."""
     if fr.result is None or not hasattr(fr.result, "params"):
         return None
@@ -274,7 +272,7 @@ def s_from_result(fr: FitResult[MiniT], which: str) -> dict[str, float] | None:
 def build_fitters(
     *,
     include_odr: bool = True,
-) -> dict[str, Callable[[Dataset], FitResult[MiniT]]]:
+) -> dict[str, Callable[[Dataset], FitResult]]:
     """Build dictionary of fitting methods for benchmarking.
 
     Returns a registry of named fitters using the unified ``fit_binding_glob``
@@ -287,10 +285,10 @@ def build_fitters(
 
     Returns
     -------
-    dict[str, Callable[[Dataset], FitResult[MiniT]]]
+    dict[str, Callable[[Dataset], FitResult]]
         Named fitters mapping.
     """
-    fitters: dict[str, Callable[[Dataset], FitResult[MiniT]]] = {
+    fitters: dict[str, Callable[[Dataset], FitResult]] = {
         # --- Standard WLS ---
         "glob_ls": fit_binding_glob,
         # --- Huber robust ---
@@ -311,11 +309,9 @@ def build_fitters(
 
     if include_odr:
 
-        def _odr(ds: Dataset) -> FitResult[MiniT]:
+        def _odr(ds: Dataset) -> FitResult:
             base = fit_binding_glob(ds)
-            return cast(
-                "FitResult[MiniT]", fit_binding_odr(base, remove_outliers="zscore:3.0")
-            )
+            return fit_binding_odr(base, remove_outliers="zscore:3.0")
 
         fitters["odr_recursive_outlier"] = _odr
 

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -2303,7 +2303,7 @@ def test_fit_binding_pymc_multi_reuses_one_summary_for_all_wells(
         assert trace_obj is trace
         assert set(per_well_fit_results) == {"A01", "A02"}
         per_well_calls["count"] += 1
-        return {key: FitResult(mini=trace) for key in per_well_fit_results}
+        return {key: FitResult(trace=trace) for key in per_well_fit_results}
 
     def fake_pm_sample(*_unused_args: object, **_unused_kwargs: object) -> xr.DataTree:
         return trace

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -34,7 +34,6 @@ from clophfit.fitting.data_structures import (
     DataArray,
     Dataset,
     FitResult,
-    MiniT,
     MultiFitResult,
     NoiseModelParams,
     PlateNoiseModel,
@@ -383,7 +382,7 @@ def test_fit_binding_pymc_data_priors_skips_lmfit(
     """The data-prior strategy should not run the LMFit prefit."""
     pytest.importorskip("pymc")
 
-    def fail_lmfit(*_args: object, **_kwargs: object) -> FitResult[Any]:
+    def fail_lmfit(*_args: object, **_kwargs: object) -> FitResult:
         msg = "fit_binding_glob should not be called"
         raise AssertionError(msg)
 
@@ -430,7 +429,7 @@ def test_normalize_fit_inputs_data_priors_skips_lmfit(
 ) -> None:
     """Multi-well normalization should seed from data without calling LMFit."""
 
-    def fail_lmfit(*_args: object, **_kwargs: object) -> FitResult[Any]:
+    def fail_lmfit(*_args: object, **_kwargs: object) -> FitResult:
         msg = "fit_binding_glob should not be called"
         raise AssertionError(msg)
 
@@ -458,7 +457,7 @@ def test_normalize_fit_inputs_data_priors_ignores_prefit_result(
 ) -> None:
     """A supplied FitResult should be re-seeded from its dataset, not reused."""
 
-    def fail_lmfit(*_args: object, **_kwargs: object) -> FitResult[Any]:
+    def fail_lmfit(*_args: object, **_kwargs: object) -> FitResult:
         msg = "fit_binding_glob should not be called"
         raise AssertionError(msg)
 
@@ -489,7 +488,7 @@ def test_fit_binding_pymc_multi_data_priors_skips_lmfit(
     scheme = PlateScheme()
     scheme.names = {"ctrl": {"A01", "A02"}}
 
-    def fail_lmfit(*_args: object, **_kwargs: object) -> FitResult[Any]:
+    def fail_lmfit(*_args: object, **_kwargs: object) -> FitResult:
         msg = "fit_binding_glob should not be called"
         raise AssertionError(msg)
 
@@ -1295,8 +1294,8 @@ def test_fit_binding_pymc_residual_refit_uses_requested_two_pass_settings(
     calls: list[dict[str, Any]] = []
 
     def fake_fit_binding_pymc(
-        ds_or_fr: Dataset | FitResult[MiniT], **kwargs: object
-    ) -> FitResult[MiniT]:
+        ds_or_fr: Dataset | FitResult, **kwargs: object
+    ) -> FitResult:
         ds = ds_or_fr.dataset if isinstance(ds_or_fr, FitResult) else ds_or_fr
         assert ds is not None
         calls.append({
@@ -1347,8 +1346,8 @@ def test_fit_binding_pymc_residual_refit_masks_one_outlier_per_label_by_default(
     calls: list[Dataset] = []
 
     def fake_fit_binding_pymc(
-        ds_or_fr: Dataset | FitResult[MiniT], **_kwargs: object
-    ) -> FitResult[MiniT]:
+        ds_or_fr: Dataset | FitResult, **_kwargs: object
+    ) -> FitResult:
         ds = ds_or_fr.dataset if isinstance(ds_or_fr, FitResult) else ds_or_fr
         assert ds is not None
         calls.append(ds.copy())
@@ -1398,8 +1397,8 @@ def test_fit_binding_pymc_residual_refit_proportional_noise_strategy(
     calls: list[dict[str, Any]] = []
 
     def fake_fit_binding_pymc(
-        ds_or_fr: Dataset | FitResult[MiniT], **kwargs: object
-    ) -> FitResult[MiniT]:
+        ds_or_fr: Dataset | FitResult, **kwargs: object
+    ) -> FitResult:
         ds = ds_or_fr.dataset if isinstance(ds_or_fr, FitResult) else ds_or_fr
         assert ds is not None
         calls.append({
@@ -1453,13 +1452,13 @@ def test_fit_binding_pymc_multi_residual_refit_uses_well_noise_scale(
     }
     calls: list[dict[str, Any]] = []
 
-    def input_label1_mask(value: Dataset | FitResult[MiniT]) -> list[bool]:
+    def input_label1_mask(value: Dataset | FitResult) -> list[bool]:
         dataset = value.dataset if isinstance(value, FitResult) else value
         assert dataset is not None
         return [bool(v) for v in dataset["1"].mask.copy().tolist()]
 
     def fake_fit_binding_pymc_multi(
-        fit_inputs: dict[str, Dataset | FitResult[MiniT]],
+        fit_inputs: dict[str, Dataset | FitResult],
         _scheme: PlateScheme,
         **kwargs: object,
     ) -> MultiFitResult:
@@ -1472,7 +1471,7 @@ def test_fit_binding_pymc_multi_residual_refit_uses_well_noise_scale(
             },
             **kwargs,
         })
-        fit_results: dict[str, FitResult[MiniT]] = {}
+        fit_results: dict[str, FitResult] = {}
         for well, item in fit_inputs.items():
             if isinstance(item, FitResult):
                 fit_results[well] = item
@@ -1545,12 +1544,12 @@ def test_fit_binding_pymc_multi_residual_refit_can_share_well_noise_scale(
     calls: list[dict[str, object]] = []
 
     def fake_fit_binding_pymc_multi(
-        fit_inputs: dict[str, Dataset | FitResult[MiniT]],
+        fit_inputs: dict[str, Dataset | FitResult],
         _scheme: PlateScheme,
         **kwargs: object,
     ) -> MultiFitResult:
         calls.append(kwargs)
-        fit_results: dict[str, FitResult[MiniT]] = {}
+        fit_results: dict[str, FitResult] = {}
         for well, item in fit_inputs.items():
             fit_results[well] = (
                 item if isinstance(item, FitResult) else fit_binding_glob(item)
@@ -2294,12 +2293,12 @@ def test_fit_binding_pymc_multi_reuses_one_summary_for_all_wells(
 
     def fake_per_well_fit_results_from_trace(
         trace_obj: xr.DataTree,
-        per_well_fit_results: dict[str, FitResult[MiniT]],
+        per_well_fit_results: dict[str, FitResult],
         per_well_scheme: PlateScheme,
         *,
         x_error_model: str,
         global_p_names: object = (),
-    ) -> dict[str, FitResult[xr.DataTree]]:
+    ) -> dict[str, FitResult]:
         del per_well_scheme, x_error_model, global_p_names
         assert trace_obj is trace
         assert set(per_well_fit_results) == {"A01", "A02"}
@@ -2543,7 +2542,7 @@ def test_fit_binding_pymc_empty_result() -> None:
     """Test that fit_binding_pymc handles empty FitResult gracefully."""
     pytest.importorskip("pymc")
     # Create an empty FitResult
-    empty_result: FitResult[MiniT] = FitResult()
+    empty_result: FitResult = FitResult()
     # Should return empty result without crashing
     result = fit_binding_pymc(empty_result, sampler=SamplerConfig(n_samples=10))
     assert result.result is None or result.mini is None
@@ -2822,7 +2821,7 @@ class TestYerrExtraction:
         params[f"S0_{lbl}"].stderr = 1.0
         params.add(f"S1_{lbl}", value=0.0)
         params[f"S1_{lbl}"].stderr = 1.0
-        fr: FitResult[MiniT] = FitResult(
+        fr: FitResult = FitResult(
             None,
             type("Result", (), {"params": params})(),
             mini=None,
@@ -2882,7 +2881,7 @@ class TestYerrExtraction:
         params[f"S0_{lbl}"].stderr = 1.0
         params.add(f"S1_{lbl}", value=0.0)
         params[f"S1_{lbl}"].stderr = 1.0
-        fr: FitResult[MiniT] = FitResult(
+        fr: FitResult = FitResult(
             None,
             type("Result", (), {"params": params})(),
             mini=None,

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -2450,15 +2450,15 @@ def test_single_and_multi_pymc_none_noise_model_estimate_similar_ye_mags(
             sampler=SamplerConfig(n_samples=150, n_tune=150),
         )
 
-        assert single.mini is not None
+        assert single.trace is not None
         if shared_ye_mags:
-            assert posterior_mean(single.mini, "ye_mag") == pytest.approx(
+            assert posterior_mean(single.trace, "ye_mag") == pytest.approx(
                 posterior_mean(multi.trace, "ye_mag"), abs=0.35
             )
         else:
             for lbl in ("1", "2"):
                 var_name = f"ye_mag_{lbl}"
-                assert posterior_mean(single.mini, var_name) == pytest.approx(
+                assert posterior_mean(single.trace, var_name) == pytest.approx(
                     posterior_mean(multi.trace, var_name), abs=0.35
                 )
 
@@ -2480,7 +2480,7 @@ def test_fit_binding_pymc_smoke_test(ph_dataset: Dataset) -> None:
         initial_fit, n_xerr=0, n_sd=10.0, sampler=SamplerConfig(n_samples=50)
     )
     # Check that we got a result
-    assert fit_result_pymc.mini is not None
+    assert fit_result_pymc.trace is not None
     assert fit_result_pymc.result is not None
     # Check that parameters are in the result
     assert "K" in fit_result_pymc.result.params
@@ -2823,7 +2823,10 @@ class TestYerrExtraction:
         params.add(f"S1_{lbl}", value=0.0)
         params[f"S1_{lbl}"].stderr = 1.0
         fr: FitResult[MiniT] = FitResult(
-            None, type("Result", (), {"params": params})(), None, ph_dataset
+            None,
+            type("Result", (), {"params": params})(),
+            mini=None,
+            dataset=ph_dataset,
         )
 
         results = {"A01": fr}
@@ -2880,7 +2883,10 @@ class TestYerrExtraction:
         params.add(f"S1_{lbl}", value=0.0)
         params[f"S1_{lbl}"].stderr = 1.0
         fr: FitResult[MiniT] = FitResult(
-            None, type("Result", (), {"params": params})(), None, ph_dataset
+            None,
+            type("Result", (), {"params": params})(),
+            mini=None,
+            dataset=ph_dataset,
         )
 
         results = {"A01": fr}

--- a/tests/test_bayesian_x_error.py
+++ b/tests/test_bayesian_x_error.py
@@ -71,9 +71,9 @@ def test_fit_binding_pymc_x_error_adjustment() -> None:
     fit_res = bayes.fit_binding_pymc(
         fr, n_xerr=1.0, sampler=SamplerConfig(n_samples=4000, random_seed=42)
     )
-    assert fit_res.mini is not None
-    assert hasattr(fit_res.mini, "posterior")
-    trace = fit_res.mini
+    assert fit_res.trace is not None
+    assert hasattr(fit_res.trace, "posterior")
+    trace = fit_res.trace
 
     # 3. Analyze Results
     # Keep full float precision: ``az.summary`` rounds to 2 decimals by default,

--- a/tests/test_bayesian_x_error.py
+++ b/tests/test_bayesian_x_error.py
@@ -60,7 +60,7 @@ def test_fit_binding_pymc_x_error_adjustment() -> None:
     params.add("S0_test_sample", value=s0_true)
     params.add("S1_test_sample", value=s1_true)
 
-    fr: FitResult[_Result] = FitResult(dataset=ds, result=_Result(params))
+    fr: FitResult = FitResult(dataset=ds, result=_Result(params))
 
     # 2. Run Bayesian Fit with x-error modeling
     # n_xerr=1.0 enables x_true modeling. The x-true shift competes with the

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -87,7 +87,7 @@ def test_extract_params_reads_lmfit_value_and_stderr() -> None:
     params["K"].stderr = 0.15
     params.add("S0_a", value=100.0)
 
-    fr: FitResult[typing.Any] = FitResult(result=_ResultWithParams(params))
+    fr: FitResult = FitResult(result=_ResultWithParams(params))
 
     assert extract_params(fr, "K") == (7.2, 0.15)
     val, err = extract_params(fr, "S0_a")
@@ -100,9 +100,9 @@ def test_extract_params_returns_nan_for_missing_result_or_parameter() -> None:
     params = Parameters()
     params.add("K", value=7.2)
 
-    no_result: FitResult[typing.Any] = FitResult()
-    no_params: FitResult[typing.Any] = FitResult(result=object())
-    missing_param: FitResult[typing.Any] = FitResult(result=_ResultWithParams(params))
+    no_result: FitResult = FitResult()
+    no_params: FitResult = FitResult(result=object())
+    missing_param: FitResult = FitResult(result=_ResultWithParams(params))
 
     assert all(np.isnan(value) for value in extract_params(no_result, "K"))
     assert all(np.isnan(value) for value in extract_params(no_params, "K"))

--- a/tests/test_fit_comparison.py
+++ b/tests/test_fit_comparison.py
@@ -18,7 +18,7 @@ import pandas as pd
 import pytest
 
 from clophfit.fitting.core import fit_binding_glob, weight_multi_ds_titration
-from clophfit.fitting.data_structures import DataArray, Dataset, FitResult, MiniT
+from clophfit.fitting.data_structures import DataArray, Dataset, FitResult
 from clophfit.fitting.models import binding_1site
 
 
@@ -90,7 +90,7 @@ def test_compare_lm_variants(
     assert fr_iter.result is not None
     assert fr_iter.result.success
 
-    def _metrics(fr: FitResult[MiniT]) -> tuple[float, float]:
+    def _metrics(fr: FitResult) -> tuple[float, float]:
         r = fr.result
         if r:
             return float(r.params["K"].value), float(getattr(r, "redchi", np.nan))

--- a/tests/test_fitter_test_utils.py
+++ b/tests/test_fitter_test_utils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import typing
 from dataclasses import dataclass
 
 import numpy as np
@@ -247,7 +246,7 @@ class TestResultExtraction:
         class MockResult:
             params: Parameters
 
-        fr: FitResult[typing.Any] = FitResult(result=MockResult(params))
+        fr: FitResult = FitResult(result=MockResult(params))
         k_val, k_err = k_from_result(fr)
 
         assert k_val == 7.5
@@ -263,7 +262,7 @@ class TestResultExtraction:
         class MockResult:
             params: Parameters
 
-        fr: FitResult[typing.Any] = FitResult(result=MockResult(params))
+        fr: FitResult = FitResult(result=MockResult(params))
         k_val, k_err = k_from_result(fr)
 
         assert k_val == 8.2
@@ -271,7 +270,7 @@ class TestResultExtraction:
 
     def test_k_from_result_invalid(self) -> None:
         """Test K extraction from invalid result."""
-        fr: FitResult[typing.Any] = FitResult()  # Empty result
+        fr: FitResult = FitResult()  # Empty result
         k_val, k_err = k_from_result(fr)
 
         assert k_val is None
@@ -294,7 +293,7 @@ class TestResultExtraction:
         class MockResult:
             params: Parameters
 
-        fr: FitResult[typing.Any] = FitResult(result=MockResult(params))
+        fr: FitResult = FitResult(result=MockResult(params))
         s0_vals = s_from_result(fr, "S0")
         s1_vals = s_from_result(fr, "S1")
 
@@ -548,7 +547,7 @@ class TestEdgeCases:
         class MockResult:
             params: Parameters
 
-        fr: FitResult[typing.Any] = FitResult(result=MockResult(params))
+        fr: FitResult = FitResult(result=MockResult(params))
         s0_vals = s_from_result(fr, "S0")
         s1_vals = s_from_result(fr, "S1")
 

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -141,6 +141,25 @@ def test_fit_binding_glob_multi(multi_dataset: Dataset) -> None:
     assert np.isclose(f_res.result.params["S1_2"].value, 0.0, atol=1e-4)
 
 
+def test_fitresult_routes_backend_to_named_field(ph_dataset: Dataset) -> None:
+    """Each backend object lands in its own field, the others stay None."""
+    lm = fit_binding_glob(ph_dataset, method="lm")
+    assert lm.mini is not None
+    assert lm.trace is None
+    assert lm.odr is None
+
+    odr = fit_binding_odr(ph_dataset)
+    assert odr.odr is not None
+    assert odr.mini is None
+    assert odr.trace is None
+
+
+def test_fitresult_is_valid_true_for_each_backend(ph_dataset: Dataset) -> None:
+    """is_valid() no longer requires the lmfit-specific mini field."""
+    assert fit_binding_glob(ph_dataset, method="lm").is_valid()
+    assert not FitResult().is_valid()
+
+
 def test_fit_binding_insufficient_data() -> None:
     """It raises InsufficientDataError when data points are too few."""
     x = np.array([7.0, 8.0])

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from lmfit import Parameters  # type: ignore[import-untyped]
-from lmfit.minimizer import Minimizer, MinimizerResult  # type: ignore[import-untyped]
+from lmfit.minimizer import MinimizerResult  # type: ignore[import-untyped]
 from matplotlib.figure import Figure
 
 from clophfit.fitting.bayes import (
@@ -657,7 +657,7 @@ def test_fit_binding_edge_cases() -> None:
 
 
 @pytest.fixture
-def mock_fit_result() -> FitResult[MinimizerResult]:
+def mock_fit_result() -> FitResult:
     """Mock a successful fit result."""
     result = MinimizerResult()
     result.success = True
@@ -668,7 +668,7 @@ def mock_fit_result() -> FitResult[MinimizerResult]:
     return FitResult(result=result)
 
 
-def test_plot_fit_with_mock(mock_fit_result: FitResult[MinimizerResult]) -> None:
+def test_plot_fit_with_mock(mock_fit_result: FitResult) -> None:
     """Test plotting with mocked fit result."""
     fig = plt.figure()
     ax = fig.add_subplot(111)
@@ -739,7 +739,7 @@ def _create_synthetic_dataset(  # noqa: PLR0913
 
 def _fit_binding_glob_huber_outlier(
     ds: Dataset, *, threshold: float = 2.5
-) -> FitResult[Minimizer]:
+) -> FitResult:
     """Run the supported robust fit with z-score outlier removal."""
     return fit_binding_glob(
         ds,
@@ -1119,7 +1119,7 @@ def test_extract_sigma_df_falls_back_to_ye_mag_without_az_summary() -> None:
         },
         is_ph=True,
     )
-    fr: FitResult[xr.DataTree] = FitResult(dataset=ds)
+    fr: FitResult = FitResult(dataset=ds)
 
     sigma_df = extract_sigma_df(trace, {"A01": fr})
 
@@ -1129,9 +1129,7 @@ def test_extract_sigma_df_falls_back_to_ye_mag_without_az_summary() -> None:
     np.testing.assert_allclose(sigma_df["hdi_97%"].to_numpy(), np.array([39.4, 78.8]))
 
 
-def _make_direct_sigma_trace_and_results() -> tuple[
-    xr.DataTree, dict[str, FitResult[xr.DataTree]]
-]:
+def _make_direct_sigma_trace_and_results() -> tuple[xr.DataTree, dict[str, FitResult]]:
     posterior = xr.Dataset(
         data_vars={
             "sigma_obs_1_A01": (
@@ -1159,7 +1157,7 @@ def _make_direct_sigma_trace_and_results() -> tuple[
         {"1": DataArray(np.array([6.0, 7.0, 8.0]), np.array([9.0, 10.0, 11.0]))},
         is_ph=True,
     )
-    results: dict[str, FitResult[xr.DataTree]] = {
+    results: dict[str, FitResult] = {
         "A01": FitResult(dataset=ds_a01),
         "A02": FitResult(dataset=ds_a02),
     }

--- a/tests/test_model_validation_smoke.py
+++ b/tests/test_model_validation_smoke.py
@@ -137,8 +137,8 @@ def test_residual_diagnostics_relative_well_scaled_and_trace_summary() -> None:
         is_ph=True,
     )
     results = {
-        "A01": FitResult(result=object(), mini=trace, dataset=dataset),
-        "A02": FitResult(result=object(), mini=trace, dataset=dataset),
+        "A01": FitResult(result=object(), trace=trace, dataset=dataset),
+        "A02": FitResult(result=object(), trace=trace, dataset=dataset),
     }
 
     diag = (
@@ -671,7 +671,7 @@ def test_residuals_from_multifit_does_not_double_apply_ye_mag() -> None:
         is_ph=True,
     )
     fr = FitResult(
-        result=type("Result", (), {"params": params})(), mini=trace, dataset=ds
+        result=type("Result", (), {"params": params})(), trace=trace, dataset=ds
     )
     multi = MultiFitResult(trace=trace, results={"A01": fr})
 
@@ -703,7 +703,7 @@ def test_residuals_from_multifit_returns_convenient_schema() -> None:
         is_ph=True,
     )
     fr = FitResult(
-        result=type("Result", (), {"params": params})(), mini=trace, dataset=ds
+        result=type("Result", (), {"params": params})(), trace=trace, dataset=ds
     )
     multi = MultiFitResult(trace=trace, results={"A01": fr})
 
@@ -746,7 +746,7 @@ def test_residuals_from_multifit_maps_outlier_probability_by_point() -> None:
         )
         return FitResult(
             result=type("Result", (), {"params": params})(),
-            mini=trace,
+            trace=trace,
             dataset=ds,
         )
 

--- a/tests/test_model_validation_smoke.py
+++ b/tests/test_model_validation_smoke.py
@@ -822,7 +822,7 @@ def _single_well_fit_result(mini: object) -> FitResult[Any]:
     y = binding_1site(x, 7.0, 100.0, 200.0, is_ph=True) + np.array([1.0, 0.0, 40.0])
     ds = Dataset({"1": DataArray(x, y, y_errc=np.array([1.0, 1.0, 2.0]))}, is_ph=True)
     result = cast("Any", type("Result", (), {"params": params})())
-    return FitResult(result=result, dataset=ds, mini=cast("Any", mini))
+    return FitResult(result=result, dataset=ds, trace=cast("Any", mini))
 
 
 def test_single_well_residuals_extract_p_outlier_from_mixture_trace() -> None:

--- a/tests/test_model_validation_smoke.py
+++ b/tests/test_model_validation_smoke.py
@@ -177,7 +177,7 @@ def test_residual_comparison_from_fit_results_and_value_switch() -> None:
     x = np.array([6.0, 7.0, 8.0])
     y = binding_1site(x, 7.0, 100.0, 200.0, is_ph=True) + np.array([1.0, 0.0, -1.0])
     ds = Dataset({"1": DataArray(x, y, y_errc=np.ones_like(y))}, is_ph=True)
-    fr: FitResult[Any] = FitResult(
+    fr: FitResult = FitResult(
         result=type("Result", (), {"params": params})(), dataset=ds
     )
 
@@ -312,7 +312,7 @@ def test_masked_datasets_from_residual_outliers_masks_marked_rows() -> None:
         },
         is_ph=True,
     )
-    fr: FitResult[Any] = FitResult(result=object(), dataset=ds)
+    fr: FitResult = FitResult(result=object(), dataset=ds)
     residuals = pd.DataFrame({
         "well": ["A01"],
         "label": ["1"],
@@ -450,7 +450,7 @@ def test_pareto_k_table_maps_multiwell_likelihood_rows(
             is_ph=True,
         )
 
-    results: dict[str, FitResult[Any]] = {
+    results: dict[str, FitResult] = {
         "A01": FitResult(
             dataset=ds(
                 np.array([10.0, 11.0, 12.0]),
@@ -612,7 +612,7 @@ def test_ctr_summary_classical_rows_and_prior_widening() -> None:
         def __init__(self) -> None:
             self.names = {"ctrl": {"A01", "A02", "A03"}}
 
-    def fit_result(k: float, stderr: float | None) -> FitResult[Any]:
+    def fit_result(k: float, stderr: float | None) -> FitResult:
         params = Parameters()
         params.add("K", value=k)
         params["K"].stderr = stderr
@@ -739,7 +739,7 @@ def test_residuals_from_multifit_maps_outlier_probability_by_point() -> None:
     x = np.array([6.0, 7.0])
     y = binding_1site(x, 7.0, 100.0, 200.0, is_ph=True)
 
-    def fit_result() -> FitResult[xr.DataTree]:
+    def fit_result() -> FitResult:
         ds = Dataset(
             {"1": DataArray(x, y, y_errc=np.array([10.0, 20.0]))},
             is_ph=True,
@@ -792,7 +792,7 @@ def test_residuals_from_fit_results_robust_params_and_drop_invalid_sigma() -> No
         {"1": DataArray(x, y, y_errc=np.array([1.0, 0.0, 2.0]))},
         is_ph=True,
     )
-    fr: FitResult[Any] = FitResult(
+    fr: FitResult = FitResult(
         result=type("Result", (), {"params": params})(), dataset=ds
     )
 
@@ -812,7 +812,7 @@ def test_residuals_from_fit_results_robust_params_and_drop_invalid_sigma() -> No
     assert residuals["is_residual_outlier"].any()
 
 
-def _single_well_fit_result(mini: object) -> FitResult[Any]:
+def _single_well_fit_result(mini: object) -> FitResult:
     """Build a minimal single-well FitResult carrying *mini* as its trace."""
     params = Parameters()
     params.add("K", value=7.0)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -62,14 +62,12 @@ def test_fgls_plate_fit_uses_calibration_fallback_and_second_pass(
     """FGLS should continue with fixed floors when calibration raises."""
     methods: list[str] = []
 
-    def fake_fit(
-        ds: Dataset, *, method: str = "lm", **_kwargs: object
-    ) -> FitResult[Any]:
+    def fake_fit(ds: Dataset, *, method: str = "lm", **_kwargs: object) -> FitResult:
         methods.append(method)
         return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
 
     def fake_residuals(
-        results: dict[str, FitResult[Any]], *_args: object, **_kwargs: object
+        results: dict[str, FitResult], *_args: object, **_kwargs: object
     ) -> pd.DataFrame:
         assert "A01" in results
         return pd.DataFrame({
@@ -121,9 +119,7 @@ def test_fgls_plate_fit_converges_and_handles_failed_well(
     """FGLS should insert empty FitResult for failed wells."""
     calls = 0
 
-    def fake_fit(
-        ds: Dataset, *, method: str = "lm", **_kwargs: object
-    ) -> FitResult[Any]:
+    def fake_fit(ds: Dataset, *, method: str = "lm", **_kwargs: object) -> FitResult:
         nonlocal calls
         assert method in {"huber", "lm"}
         calls += 1
@@ -133,7 +129,7 @@ def test_fgls_plate_fit_converges_and_handles_failed_well(
         return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
 
     def fake_residuals(
-        _results: dict[str, FitResult[Any]], *_args: object, **_kwargs: object
+        _results: dict[str, FitResult], *_args: object, **_kwargs: object
     ) -> pd.DataFrame:
         return pd.DataFrame({
             "well": ["good"],

--- a/tests/test_production_methods.py
+++ b/tests/test_production_methods.py
@@ -1,6 +1,6 @@
 """Tests for supported production fitting methods."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from clophfit.fitting.core import fit_binding_glob
 from clophfit.fitting.data_structures import Dataset, FitResult
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def _fit_huber_outlier(ds: Dataset) -> FitResult[Any]:
+def _fit_huber_outlier(ds: Dataset) -> FitResult:
     """Run the supported robust LM configuration with outlier removal."""
     return fit_binding_glob(ds, method="huber", remove_outliers="zscore:2.5:5")
 
@@ -64,7 +64,7 @@ def test_all_production_methods_converge(ph_dataset: Dataset) -> None:
     assert lm_result.result is not None
     assert lm_result.result.success, "LM failed"
 
-    odr_methods: list[tuple[str, Callable[[FitResult[Any]], FitResult[Any]]]] = [
+    odr_methods: list[tuple[str, Callable[[FitResult], FitResult]]] = [
         ("ODR-Recursive", lambda fr: fit_binding_odr(fr, reweight=True)),
         (
             "ODR-Recursive+Outlier",

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from lmfit.minimizer import MinimizerResult  # type: ignore[import-untyped]
 
 from clophfit.fitting.core import fit_binding_glob
 from clophfit.fitting.data_structures import (
@@ -45,7 +44,7 @@ from clophfit.fitting.residuals import (
 
 
 @pytest.fixture
-def simple_fit_result() -> FitResult[MinimizerResult]:
+def simple_fit_result() -> FitResult:
     """Create a simple fit result for testing residuals."""
     x = np.array([9.0, 8.0, 7.0, 6.0, 5.0])
     # Perfect fit data with K=7, adding tiny noise to avoid zero-division in lmfit
@@ -58,7 +57,7 @@ def simple_fit_result() -> FitResult[MinimizerResult]:
 
 
 @pytest.fixture
-def noisy_fit_result() -> FitResult[MinimizerResult]:
+def noisy_fit_result() -> FitResult:
     """Create a fit result with noisy data."""
     rng = np.random.default_rng(42)
     x = np.array([9.0, 8.0, 7.0, 6.0, 5.0])
@@ -71,7 +70,7 @@ def noisy_fit_result() -> FitResult[MinimizerResult]:
 
 
 @pytest.fixture
-def multi_label_fit_result() -> FitResult[MinimizerResult]:
+def multi_label_fit_result() -> FitResult:
     """Create a multi-label fit result."""
     x = np.array([9.0, 8.0, 7.0, 6.0, 5.0])
     y1 = binding_1site(x, K=7.0, S0=500.0, S1=1000.0, is_ph=True)
@@ -87,7 +86,7 @@ def multi_label_fit_result() -> FitResult[MinimizerResult]:
 
 
 @pytest.fixture
-def empty_fit_result() -> FitResult[MinimizerResult]:
+def empty_fit_result() -> FitResult:
     """Create a fit result with no result."""
     return FitResult(result=None, dataset=None)
 
@@ -146,7 +145,7 @@ class TestResidualPoint:
 class TestExtractResidualPoints:
     """Test the extract_residual_points function."""
 
-    def test_single_label(self, simple_fit_result: FitResult[MinimizerResult]) -> None:
+    def test_single_label(self, simple_fit_result: FitResult) -> None:
         """Test extraction from single-label fit."""
         points = extract_residual_points(simple_fit_result)
         assert len(points) == 5
@@ -154,9 +153,7 @@ class TestExtractResidualPoints:
         assert all(isinstance(p.std_res, float) for p in points)
         assert all(isinstance(p.raw_res, float) for p in points)
 
-    def test_multi_label(
-        self, multi_label_fit_result: FitResult[MinimizerResult]
-    ) -> None:
+    def test_multi_label(self, multi_label_fit_result: FitResult) -> None:
         """Test extraction from multi-label fit."""
         points = extract_residual_points(multi_label_fit_result)
         assert len(points) == 10  # 5 points * 2 labels
@@ -165,23 +162,19 @@ class TestExtractResidualPoints:
         assert len(y1_points) == 5
         assert len(y2_points) == 5
 
-    def test_empty_result(self, empty_fit_result: FitResult[MinimizerResult]) -> None:
+    def test_empty_result(self, empty_fit_result: FitResult) -> None:
         """Test extraction from empty fit result."""
         points = extract_residual_points(empty_fit_result)
         assert points == []
 
-    def test_x_values_preserved(
-        self, simple_fit_result: FitResult[MinimizerResult]
-    ) -> None:
+    def test_x_values_preserved(self, simple_fit_result: FitResult) -> None:
         """Test that x values are preserved in residual points."""
         points = extract_residual_points(simple_fit_result)
         x_values = {p.x for p in points}
         expected_x = {9.0, 8.0, 7.0, 6.0, 5.0}
         assert x_values == expected_x
 
-    def test_raw_indices_sequential(
-        self, simple_fit_result: FitResult[MinimizerResult]
-    ) -> None:
+    def test_raw_indices_sequential(self, simple_fit_result: FitResult) -> None:
         """Test that raw indices are sequential when no masking is applied."""
         points = extract_residual_points(simple_fit_result)
         indices = [p.raw_i for p in points]
@@ -214,7 +207,7 @@ class TestExtractResidualPoints:
 class TestResidualDataframe:
     """Test the residual_dataframe function."""
 
-    def test_columns(self, simple_fit_result: FitResult[MinimizerResult]) -> None:
+    def test_columns(self, simple_fit_result: FitResult) -> None:
         """Test that DataFrame has correct columns."""
         df = residual_dataframe(simple_fit_result)
         expected_cols = {
@@ -230,12 +223,12 @@ class TestResidualDataframe:
         }
         assert set(df.columns) == expected_cols
 
-    def test_row_count(self, simple_fit_result: FitResult[MinimizerResult]) -> None:
+    def test_row_count(self, simple_fit_result: FitResult) -> None:
         """Test that DataFrame has correct number of rows."""
         df = residual_dataframe(simple_fit_result)
         assert len(df) == 5
 
-    def test_empty_result(self, empty_fit_result: FitResult[MinimizerResult]) -> None:
+    def test_empty_result(self, empty_fit_result: FitResult) -> None:
         """Test DataFrame from empty fit result."""
         df = residual_dataframe(empty_fit_result)
         assert len(df) == 0
@@ -245,7 +238,7 @@ class TestResidualsEntryPoint:
     """The FitResult.residuals cached-property entry point."""
 
     def test_fitresult_residuals_canonical_and_cached(
-        self, simple_fit_result: FitResult[MinimizerResult]
+        self, simple_fit_result: FitResult
     ) -> None:
         """fr.residuals returns the canonical schema and is cached."""
         r = simple_fit_result.residuals
@@ -254,9 +247,7 @@ class TestResidualsEntryPoint:
         )
         assert simple_fit_result.residuals is r  # cached (same object)
 
-    def test_residual_table_override(
-        self, simple_fit_result: FitResult[MinimizerResult]
-    ) -> None:
+    def test_residual_table_override(self, simple_fit_result: FitResult) -> None:
         """residual_table(...) yields the same columns as the property."""
         table = simple_fit_result.residual_table(robust=False)
         assert list(table.columns) == list(simple_fit_result.residuals.columns)
@@ -285,7 +276,7 @@ class TestResidualsEntryPoint:
         assert robust_likelihood_from_trace(trace) == "student_t"
         assert robust_likelihood_from_trace(None) == "normal"
 
-    def test_dtypes(self, simple_fit_result: FitResult[MinimizerResult]) -> None:
+    def test_dtypes(self, simple_fit_result: FitResult) -> None:
         """Test DataFrame column dtypes."""
         df = residual_dataframe(simple_fit_result)
         assert pd.api.types.is_string_dtype(df["label"])
@@ -303,7 +294,7 @@ class TestResidualsEntryPoint:
 class TestResidualStatistics:
     """Test the residual_statistics function."""
 
-    def test_columns(self, simple_fit_result: FitResult[MinimizerResult]) -> None:
+    def test_columns(self, simple_fit_result: FitResult) -> None:
         """Test that statistics DataFrame has expected columns."""
         results = {"A01": simple_fit_result}
         df = residuals_from_fit_results(
@@ -321,9 +312,7 @@ class TestResidualStatistics:
         }
         assert expected_cols.issubset(set(stats.columns))
 
-    def test_grouped_by_label(
-        self, multi_label_fit_result: FitResult[MinimizerResult]
-    ) -> None:
+    def test_grouped_by_label(self, multi_label_fit_result: FitResult) -> None:
         """Test that statistics are grouped by label."""
         results = {"A01": multi_label_fit_result}
         df = residuals_from_fit_results(
@@ -491,7 +480,7 @@ class TestResidualDiagnosticsHelpers:
 class TestValidateResiduals:
     """Test ResidualAnalysis.validate residual-quality checks."""
 
-    def test_good_fit(self, simple_fit_result: FitResult[MinimizerResult]) -> None:
+    def test_good_fit(self, simple_fit_result: FitResult) -> None:
         """Test validation of a good fit."""
         checks = ResidualAnalysis(simple_fit_result.residuals).validate(verbose=False)
         assert isinstance(checks, dict)
@@ -499,7 +488,7 @@ class TestValidateResiduals:
         assert "outliers_ok" in checks
         assert "correlation_ok" in checks
 
-    def test_empty_result(self, empty_fit_result: FitResult[MinimizerResult]) -> None:
+    def test_empty_result(self, empty_fit_result: FitResult) -> None:
         """Test validation of empty fit result."""
         checks = ResidualAnalysis(empty_fit_result.residuals).validate(verbose=False)
         # All checks should pass (no data to fail on)
@@ -525,7 +514,7 @@ class TestValidateResiduals:
 
     def test_verbose_output(
         self,
-        noisy_fit_result: FitResult[MinimizerResult],
+        noisy_fit_result: FitResult,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """Test that verbose mode produces output."""
@@ -534,7 +523,7 @@ class TestValidateResiduals:
         # Verbose mode should produce some output (may or may not warn)
         assert isinstance(captured.out, str)
 
-    def test_returns_dict(self, noisy_fit_result: FitResult[MinimizerResult]) -> None:
+    def test_returns_dict(self, noisy_fit_result: FitResult) -> None:
         """Test that function returns correct structure."""
         checks = ResidualAnalysis(noisy_fit_result.residuals).validate(verbose=False)
         assert set(checks.keys()) == {"bias_ok", "outliers_ok", "correlation_ok"}

--- a/tests/test_titration_fit_plate.py
+++ b/tests/test_titration_fit_plate.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import pytest
@@ -44,17 +43,15 @@ def test_fit_plate_routes_methods_and_preserves_well_keys(
     """Plate fitting should dispatch each method to the intended backend."""
     calls: list[tuple[str, str]] = []
 
-    def fake_glob(
-        ds: Dataset, *, method: str = "lm", **_kwargs: object
-    ) -> FitResult[Any]:
+    def fake_glob(ds: Dataset, *, method: str = "lm", **_kwargs: object) -> FitResult:
         calls.append(("glob", method))
         return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
 
-    def fake_odr(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+    def fake_odr(ds: Dataset, **_kwargs: object) -> FitResult:
         calls.append(("odr", "odr"))
         return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
 
-    def fake_mcmc(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+    def fake_mcmc(ds: Dataset, **_kwargs: object) -> FitResult:
         calls.append(("mcmc", "mcmc"))
         return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
 
@@ -76,7 +73,7 @@ def test_fit_plate_turns_insufficient_data_into_empty_result(
 ) -> None:
     """One well's insufficient-data failure must not abort the other well's fit."""
 
-    def backend(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+    def backend(ds: Dataset, **_kwargs: object) -> FitResult:
         if len(ds["1"].y) < len(_dataset()["1"].y):
             msg = "too few points"
             raise InsufficientDataError(msg)
@@ -101,7 +98,7 @@ def test_fit_plate_carries_plate_metadata(
 ) -> None:
     """The returned container carries this titration's scheme and fit_keys."""
 
-    def fake_glob(ds: Dataset, **_kwargs: object) -> FitResult[Any]:
+    def fake_glob(ds: Dataset, **_kwargs: object) -> FitResult:
         return FitResult(result=_Result(np.zeros(len(ds["1"].y))), dataset=ds)
 
     monkeypatch.setattr("clophfit.prtecan.titration.fit_binding_glob", fake_glob)


### PR DESCRIPTION
## Summary

Splits `FitResult.mini` — previously one field holding a three-way union `Minimizer | odrpack.OdrResult | xr.DataTree` — into three concrete, self-describing fields, and drops the annotation-only generic parameter:

```python
@dataclass
class FitResult:
    figure: Figure | None = None
    result: MinimizerResult | _Result | None = None
    mini:  Minimizer | None = None      # lmfit (conf_interval, emcee, userargs)
    trace: xr.DataTree | None = None    # PyMC posterior
    odr:   OdrResult | None = None      # odrpack (res_var, outlier)
    dataset: Dataset | None = None
```

Before, every consumer had to know which backend `.mini` secretly held and narrow by faith — the sharpest case being `residual_table` passing a `Minimizer` into a parameter literally named `trace`. Now each backend lands in its own field, `residual_table` reads `self.trace`, and the union footgun is gone.

## What changed

- **Three fields, generic dropped.** `class FitResult(ResidualsMixin)` (no `[MiniType]`). The generic was annotation-only — no code ever bound on it — so all 168 `FitResult[...]` annotations (src **and** tests) become plain `FitResult`, and `MiniT` / `MiniProtocol` / `MiniType` are deleted.
- **Backend routing.** lmfit → `.mini`, PyMC → `.trace`, ODR → `.odr`, at every construction site. A PyMC fit now has `mini=None` / `trace` set; an ODR fit has `mini=None` / `odr` set.
- **`is_valid()`** is now backend-agnostic: figure + result + any one of mini/trace/odr. It previously required `mini`, which would have wrongly reported a PyMC fit invalid once its trace moved out of `mini`.
- **`residual_table`** reads `self.trace` — behaviour-preserving (classical fits have `trace=None` → Normal, exactly as before; PyMC fits resolve from the trace they always carried).

## Behaviour preservation

This is a type-and-routing refactor with no intended logic change:
- Full suite green: **574 passed**; `mypy src/clophfit` clean (32 files).
- A real PyMC fit confirms `.trace` set, `.mini` None, and `residual_likelihood` resolved from the trace (not forced Normal).
- REPL routing check: lmfit populates only `.mini`, ODR only `.odr`.
- Completeness greps return nothing: no `MiniT`/`MiniProtocol`/`MiniType` and no `FitResult[` subscript remains anywhere.

## Notes

- Built with a 2-task spec → plan → per-task-review workflow plus a whole-branch review. The whole-branch review caught one dynamic `.mini`-first read in `model_validation.trace_parameter_summary` (a live instance of the very footgun this PR removes) — fixed in the final commit, along with a handful of tests that encoded the dead `FitResult(mini=<trace>)` idiom.
- Depends on and builds atop #1398 (already merged); this branch edits the `ResidualsMixin` that PR introduced.
- Design spec and plan under `docs/superpowers/` (excluded from the Sphinx build).

## Follow-up (out of scope)

`shared_floor` for the PyMC noise priors (symmetric with the existing `shared_gain`/`shared_alpha`) is the next planned change — its own spec/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
